### PR TITLE
converging on count_subsystems.py

### DIFF
--- a/bash/atavide_lite.sh
+++ b/bash/atavide_lite.sh
@@ -153,7 +153,7 @@ pigz mmseqs/atavide_tophit_report_subsystems_taxa
 #                                                                #
 ##################################################################
 
-perl ~/atavide_lite/bin/count_subsystems.pl -d mmseqs -n $SAMPLENAME
+python ~/atavide_lite/bin/count_subsystems.py -d mmseqs -n $SAMPLENAME
 find subsystems -type f -exec pigz {} \;
 
 ##################################################################

--- a/deepthought_minion/count_subsystems.slurm
+++ b/deepthought_minion/count_subsystems.slurm
@@ -15,5 +15,5 @@ fi
 
 source DEFINITIONS.sh
 
-perl ~/atavide_lite/bin/count_subsystems.pl -d mmseqs -n $SAMPLENAME
+python ~/atavide_lite/bin/count_subsystems.py -d mmseqs -n $SAMPLENAME
 find subsystems -type f -exec pigz {} \;

--- a/nci_pbs/fasta/count_subsystems.pbs
+++ b/nci_pbs/fasta/count_subsystems.pbs
@@ -14,4 +14,4 @@ set -euo pipefail
 eval "$(conda shell.bash hook)"
 conda activate bioinformatics
 
-perl ~/GitHubs/atavide_lite/bin/count_subsystems.pl -d mmseqs
+python ~/GitHubs/atavide_lite/bin/count_subsystems.py -d mmseqs

--- a/pawsey_minion/count_subsystems.slurm
+++ b/pawsey_minion/count_subsystems.slurm
@@ -15,5 +15,5 @@ fi
 
 source DEFINITIONS.sh
 
-perl ~/atavide_lite/bin/count_subsystems.pl -d mmseqs -n $SAMPLENAME
+python ~/atavide_lite/bin/count_subsystems.py -d mmseqs -n $SAMPLENAME
 find subsystems -type f -exec pigz {} \;

--- a/pawsey_shortread/count_subsystems.slurm
+++ b/pawsey_shortread/count_subsystems.slurm
@@ -15,5 +15,5 @@ fi
 
 source DEFINITIONS.sh
 
-perl ~/atavide_lite/bin/count_subsystems.pl -d mmseqs -n $SAMPLENAME
+python ~/atavide_lite/bin/count_subsystems.py -d mmseqs -n $SAMPLENAME
 find subsystems -type f -exec pigz {} \;


### PR DESCRIPTION
This pull request updates the workflow scripts to use the Python implementation of the `count_subsystems` script instead of the Perl version. This change improves consistency across different environments and likely reflects a migration to a more modern or maintained codebase.

**Script migration from Perl to Python:**

* Updated all relevant scripts (`bash/atavide_lite.sh`, `deepthought_minion/count_subsystems.slurm`, `pawsey_minion/count_subsystems.slurm`, `pawsey_shortread/count_subsystems.slurm`, and `nci_pbs/fasta/count_subsystems.pbs`) to call `count_subsystems.py` with Python instead of `count_subsystems.pl` with Perl, ensuring the same arguments are passed as before. [[1]](diffhunk://#diff-e9958246c9b0b9103626aa499988fc3a94e721ef22e140dbe8b8a40d183074a9L156-R156) [[2]](diffhunk://#diff-45c4ab3d0a8574fdba52907d5a41769245c2d812ae9346ef5c2b89765c21591aL18-R18) [[3]](diffhunk://#diff-47b302613f93534f161bf30b4cc8a6d5124c254cfa7a1f3dd7dd1dfeed14b7daL17-R17)