### PR TITLE
reducing time request for sankey plots

### DIFF
--- a/bin/sankey_plot.py
+++ b/bin/sankey_plot.py
@@ -23,8 +23,7 @@ last_serialised = time.time()
 def serialise(data, count_data_file):
     """Serialise the data to a file.
     We do this every SERIALISE_EVERY seconds to avoid losing data."""
-    readable = datetime.fromtimestamp(now).strftime("%Y-%m-%d %H:%M:%S")
-    logging.info("Serialising data to %s at %s", count_data_file, readable)
+    logging.info("Serialising data to %s at %s", count_data_file, datetime.now())
 
     # check the file names and reate the backup files
     if count_data_file.endswith(".gz"):

--- a/bin/sankey_plot.py
+++ b/bin/sankey_plot.py
@@ -23,7 +23,8 @@ last_serialised = time.time()
 def serialise(data, count_data_file):
     """Serialise the data to a file.
     We do this every SERIALISE_EVERY seconds to avoid losing data."""
-    print(f"SERIALISING to {count_data_file} at {datetime.now()}", file=sys.stderr)
+    readable = datetime.fromtimestamp(now).strftime("%Y-%m-%d %H:%M:%S")
+    logging.info("Serialising data to %s at %s", count_data_file, readable)
 
     # check the file names and reate the backup files
     if count_data_file.endswith(".gz"):
@@ -38,8 +39,6 @@ def serialise(data, count_data_file):
     now = time.time()
 
     if now - last_serialised >= SERIALISE_EVERY:
-        readable = datetime.fromtimestamp(now).strftime("%Y-%m-%d %H:%M:%S")
-        logging.info("Serialising data to %s at %s", count_data_file, readable)
         # Rotate backups
         if os.path.exists(backup1):
             shutil.move(backup1, backup2)

--- a/bin/sankey_plot.py
+++ b/bin/sankey_plot.py
@@ -23,7 +23,7 @@ last_serialised = time.time()
 def serialise(data, count_data_file):
     """Serialise the data to a file.
     We do this every SERIALISE_EVERY seconds to avoid losing data."""
-    print("SERIALISING to {count_data_file} at {datetime.now()}", file=sys.stderr)
+    print(f"SERIALISING to {count_data_file} at {datetime.now()}", file=sys.stderr)
 
     # check the file names and reate the backup files
     if count_data_file.endswith(".gz"):

--- a/deepthought_minion/sankey_plot.slurm
+++ b/deepthought_minion/sankey_plot.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=sankey_plot
-#SBATCH --time=1-0
+#SBATCH --time=0-1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=32
 #SBATCH --mem=64GB

--- a/pawsey_minion/sankey_plot.slurm
+++ b/pawsey_minion/sankey_plot.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=sankey_plot
-#SBATCH --time=1-0
+#SBATCH --time=0-1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=32
 #SBATCH --mem=64GB

--- a/pawsey_shortread/sankey_plot.slurm
+++ b/pawsey_shortread/sankey_plot.slurm
@@ -1,7 +1,7 @@
 #!/bin/bash
 #SBATCH --account=pawsey1018
 #SBATCH --job-name=sankey_plot
-#SBATCH --time=1-0
+#SBATCH --time=0-1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=32
 #SBATCH --mem=64GB


### PR DESCRIPTION
This pull request updates the SLURM job scripts for `sankey_plot` across multiple environments to reduce the maximum allowed runtime from 1 day to 1 hour. This change ensures that the jobs will time out sooner, which may help with queue management and resource allocation.

Batch script runtime limit updates:

* Changed the `#SBATCH --time` parameter from `1-0` (1 day) to `0-1` (1 hour) in `deepthought_minion/sankey_plot.slurm`.
* Changed the `#SBATCH --time` parameter from `1-0` (1 day) to `0-1` (1 hour) in `pawsey_minion/sankey_plot.slurm`.
* Changed the `#SBATCH --time` parameter from `1-0` (1 day) to `0-1` (1 hour) in `pawsey_shortread/sankey_plot.slurm`.