### PR TITLE
sankey for MGI

### DIFF
--- a/deepthought_shortread/sankey_plot.slurm
+++ b/deepthought_shortread/sankey_plot.slurm
@@ -1,0 +1,14 @@
+#!/bin/bash
+#SBATCH --job-name=sankey_plot
+#SBATCH --time=1-0
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=32
+#SBATCH --mem=64GB
+#SBATCH -o slurm_output/sankey_plot-%j.out
+#SBATCH -e slurm_output/sankey_plot-%j.err
+
+set -euo pipefail
+
+export PYTHONPATH=$PYTHONPATH:~/GitHubs/atavide_lite
+python ~/GitHubs/atavide_lite/bin/sankey_plot.py -r R1_reads.txt  --paired -v
+


### PR DESCRIPTION
This pull request adds a new SLURM batch script to automate running the Sankey plot generation as a job on a compute cluster.

New SLURM job script:

* Added `deepthought_shortread/sankey_plot.slurm` to submit a job for running `sankey_plot.py` with specified resources (1 task, 32 CPUs, 64GB memory), output/error logging, and environment setup.