### PR TITLE
Minor updates

### DIFF
--- a/bin/sankey_plot.py
+++ b/bin/sankey_plot.py
@@ -68,6 +68,9 @@ def deserialise(count_data_file):
 def count_fastq(fastq_file, logger=None):
     if logger:
         logger.warning(f"Counting sequences in {fastq_file}")
+    if not os.path.exists(fastq_file):
+        logger.warning(f"ERROR: {fastq_file} does not exist. 0 sequences reported")
+        return 0
     count = sum(1 for _ in stream_fastq(fastq_file))
     return count
 

--- a/bin/vamb_create_fasta.py
+++ b/bin/vamb_create_fasta.py
@@ -43,4 +43,4 @@ if not clusters:
 
 print(f"Writing {len(clusters)} bins to {args.outdir}", file=sys.stderr)
 with vamb.vambtools.Reader(args.fastapath) as file:
-    vamb.vambtools.write_bins(pathlib.Path(args.outdir), clusters, file, maxbins=None, compress_output=True)
+    vamb.vambtools.write_bins(pathlib.Path(args.outdir), clusters, file, maxbins=None)

--- a/methods/create_methods.slurm
+++ b/methods/create_methods.slurm
@@ -31,10 +31,17 @@ TKVER=$(taxonkit 2>&1 | grep Version)
 VBVER=$(vamb --version 2>/dev/null) || VBVER="Vamb 5.0.2"
 MHVER=$(megahit -v | cut -f 2 -d ' ')
 
+if [[ -e  ~/Databases/UniRef100/UniRef100.version ]]; then
+	UNIREFVER100=$(perl -pe  's/^\s+//; chomp; if ($_) {s/$/; /}' ~/Databases/UniRef100/UniRef100.version)
+else
+	UNIREFVER100="UniRef100 is Unknown - please check with mmseqs2"
+
+fi
 if [[ -e  ~/Databases/UniRef50/UniRef50.version ]]; then
 	UNIREFVER=$(perl -pe  's/^\s+//; chomp; if ($_) {s/$/; /}' ~/Databases/UniRef50/UniRef50.version)
 else
-	UNIREFVER="Unknown - please check with mmseqs2"
+	UNIREFVER="UniRef50 is Unknown - please check with mmseqs2"
+
 fi
 
 HF=`basename $HOSTFILE`
@@ -69,6 +76,8 @@ These commands use the default minimap2 parameters for mapping reads against a r
 
 The sequences were identified from the BAM file created by the previous command and filtered to two separate files using samtools  ($STVER) [PMID: 19505943]. Sequences that do not match the flag 3588 -- and thus represent mapped reads which pass the platform/vendor quality check, are not PCR or optical duplicates, and are primary alignments -- were filtered as mapping to the human genome. For short reads, additional samtools flags were used to identify R1 reads (matching flag 65) and R2 reads (matching flag 129). Reads that do not match the flag 3584 -- and thus represent unmapped reads which pass the platform/vendor quality check, are not PCR or optical duplicates, and are primary alignments -- are filtered as unmapped reads [PMID: 19505943], and again, short reads were separated using flags that match 77 for R1 reads and 141 for R2 reads.
 
+_DELETE ONE OF THESE_
+
 Reads that did not map to the human genome were mapped against the UniRef50 ($UNIREFVER) [PMID: 17379688]  (version database using MMseqs2 (version $MMVER) with the following command for long reads:
 
 mmseqs easy-taxonomy fasta/\$READS UniRef50 mmseqs/\${READS}_UniRef /tmp --threads 32
@@ -76,6 +85,18 @@ mmseqs easy-taxonomy fasta/\$READS UniRef50 mmseqs/\${READS}_UniRef /tmp --threa
 and a similar command for short-read sequencing
 
 mmseqs easy-taxonomy fasta/\$R1 fasta/\$R2 UniRef50 mmseqs/\${R1}_UniRef /tmp --threads 32
+
+_OR_
+
+Reads that did not map to the human genome were mapped against the UniRef50 ($UNIREFVER100) [PMID: 17379688]  (version database using MMseqs2 (version $MMVER) with the following command for long reads:
+
+mmseqs easy-taxonomy fasta/\$READS UniRef100 mmseqs/\${READS}_UniRef /tmp --threads 32
+
+and a similar command for short-read sequencing
+
+mmseqs easy-taxonomy fasta/\$R1 fasta/\$R2 UniRef100 mmseqs/\${R1}_UniRef /tmp --threads 32
+
+_END DELETE!_
 
 MMseqs2 easy-taxonomy parameters were optimised by the authors for a balance of sensitivity and speed and include a 7-mer double-match prefilter with compositional bias correction, low-complexity masking with TANTAN, and default similarity thresholds (--k-score ~95) that generate sufficient similar k-mers for accurate detection while maintaining computational efficiency. Candidate hits are further filtered by fast ungapped alignment and refined with vectorized Smith-Waterman alignments, after which taxonomic labels are assigned using a lowest common ancestor (LCA) approach described in more detail in their paper and on their website [PMID: 29035372].
 

--- a/pawsey_lib/check_atavide_lite_env.sh
+++ b/pawsey_lib/check_atavide_lite_env.sh
@@ -8,33 +8,50 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 ENV="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 
 if [[ ! -d "$ENV" ]]; then
-    echo "ERROR: environment directory does not exist: $ENV" >&2
+    echo "ERROR: We could not find a conda environment at: $ENV" >&2
+    echo "Please switch to the atavide lite directory and create the environment with:" >&2
+    echo "mamba env create --yes --prefix $ENV --file ../atavide_lite.yaml " >&2
     exit 1
 fi
 
 if [[ ! -x "$ENV/bin/python" ]]; then
     echo "ERROR: $ENV does not look like a valid conda env: missing bin/python" >&2
+    echo "Please switch to the atavide lite directory, remove $ENV, and recreate the environment with:" >&2
+    echo "mamba env remove --prefix $ENV" >&2
+    echo "mamba env create --yes --prefix $ENV --file ../atavide_lite.yaml " >&2
     exit 1
 fi
 
 if [[ ! -d "$ENV/conda-meta" ]]; then
     echo "ERROR: $ENV does not look like a valid conda env: missing conda-meta/" >&2
+    echo "Please switch to the atavide lite directory, remove $ENV, and recreate the environment with:" >&2
+    echo "mamba env remove --prefix $ENV" >&2
+    echo "mamba env create --yes --prefix $ENV --file ../atavide_lite.yaml " >&2
     exit 1
 fi
 
 if ! command -v conda >/dev/null 2>&1; then
     echo "ERROR: conda is not available on PATH" >&2
+    echo "Please switch to the atavide lite directory, remove $ENV, and recreate the environment with:" >&2
+    echo "mamba env remove --prefix $ENV" >&2
+    echo "mamba env create --yes --prefix $ENV --file ../atavide_lite.yaml " >&2
     exit 1
 fi
 
 if ! conda run -p "$ENV" --no-capture-output python -c 'import sys; print("Conda prefix:", sys.prefix)'; then
     echo "ERROR: conda cannot run commands inside $ENV" >&2
+    echo "Please switch to the atavide lite directory, remove $ENV, and recreate the environment with:" >&2
+    echo "mamba env remove --prefix $ENV" >&2
+    echo "mamba env create --yes --prefix $ENV --file ../atavide_lite.yaml " >&2
     exit 1
 fi
 
 for exe in samtools fastp minimap2 mmseqs megahit rclone rsync parallel pigz snakemake fasterq-dump taxonkit; do
     if ! conda run -p "$ENV" bash -lc "command -v $exe >/dev/null"; then
         echo "ERROR: missing executable in environment: $exe" >&2
+        echo "Please switch to the atavide lite directory, remove $ENV, and recreate the environment with:" >&2
+        echo "mamba env remove --prefix $ENV" >&2
+        echo "mamba env create --yes --prefix $ENV --file ../atavide_lite.yaml " >&2
         exit 1
     fi
 done

--- a/pawsey_lib/check_atavide_lite_env.sh
+++ b/pawsey_lib/check_atavide_lite_env.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+: "${PAWSEY_PROJECT:?PAWSEY_PROJECT is not set}"
+
+ENV="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+
+if [[ ! -d "$ENV" ]]; then
+    echo "ERROR: environment directory does not exist: $ENV" >&2
+    exit 1
+fi
+
+if [[ ! -x "$ENV/bin/python" ]]; then
+    echo "ERROR: $ENV does not look like a valid conda env: missing bin/python" >&2
+    exit 1
+fi
+
+if [[ ! -d "$ENV/conda-meta" ]]; then
+    echo "ERROR: $ENV does not look like a valid conda env: missing conda-meta/" >&2
+    exit 1
+fi
+
+if ! command -v conda >/dev/null 2>&1; then
+    echo "ERROR: conda is not available on PATH" >&2
+    exit 1
+fi
+
+if ! conda run -p "$ENV" --no-capture-output python -c 'import sys; print("Conda prefix:", sys.prefix)'; then
+    echo "ERROR: conda cannot run commands inside $ENV" >&2
+    exit 1
+fi
+
+for exe in samtools fastp minimap2 mmseqs megahit rclone rsync parallel pigz snakemake fasterq-dump taxonkit; do
+    if ! conda run -p "$ENV" bash -lc "command -v $exe >/dev/null"; then
+        echo "ERROR: missing executable in environment: $exe" >&2
+        exit 1
+    fi
+done
+
+echo "OK: $ENV is our atavide_lite conda environment. Continuing!"
+exit 0

--- a/pawsey_shortread/16S_detection.slurm
+++ b/pawsey_shortread/16S_detection.slurm
@@ -7,14 +7,14 @@
 #SBATCH -o slurm_output/sixteen_s/16S-%A_%a.out
 #SBATCH -e slurm_output/sixteen_s/16S-%A_%a.err
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 if [[ ! -e R1_reads.txt ]]; then

--- a/pawsey_shortread/16S_detection_single.slurm
+++ b/pawsey_shortread/16S_detection_single.slurm
@@ -9,14 +9,14 @@
 
 
 # This script runs all the 16S in one go because its actually quite quick to do
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 if [[ ! -e R1_reads.txt ]]; then

--- a/pawsey_shortread/DEFINITIONS_human.sh
+++ b/pawsey_shortread/DEFINITIONS_human.sh
@@ -1,9 +1,8 @@
 # This definitions file is for use with the HUMAN genomes. 
-# Make sure you change FILEEND/FAFILEEND
+# Make sure you change FILEEND
 
 export SAMPLENAME=xxxyyy
 export FILEEND=_R1.fastq.gz
-export FAFILEEND=_R1.fasta.gz
 export SOURCE=fastq
 export HOSTFILE=/scratch/$PAWSEY_PROJECT/$USER/Databases/human/GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.gz
 export HOST=human

--- a/pawsey_shortread/DEFINITIONS_mouse.sh
+++ b/pawsey_shortread/DEFINITIONS_mouse.sh
@@ -1,9 +1,8 @@
 # This definitions file is for use with the HUMAN genomes. 
-# Make sure you change FILEEND/FAFILEEND
+# Make sure you change FILEEND
 
 export SAMPLENAME=xxxyyy
 export FILEEND=_R1.fastq.gz
-export FAFILEEND=_R1.fasta.gz
 export SOURCE=fastq
 export HOSTFILE=/scratch/$PAWSEY_PROJECT/$USER/Databases/mouse/GCF_000001635.27_GRCm39_genomic.fna.gz
 export HOST=mouse

--- a/pawsey_shortread/DEFINITIONS_nohost.sh
+++ b/pawsey_shortread/DEFINITIONS_nohost.sh
@@ -1,0 +1,8 @@
+# this definitions file is used if there is no host.
+# You can just skip the host removal step, and then we continue using the HOSTREMOVED directory, which is
+# our cleaned files
+
+export SAMPLENAME=xxxyyy
+export FILEEND=_L001_R1_001.fastq.gz
+export SOURCE=fastq
+export HOSTREMOVED=fastq_fastp

--- a/pawsey_shortread/README.md
+++ b/pawsey_shortread/README.md
@@ -1,114 +1,233 @@
-# Process a metagenome through Rob's 2023 pipeline
-
-This is the same scripts as in [../slurm](../slurm) but I've "optimised" this to run on Pawsey. They are not optimised at all, but they run!
+# Process a metagenome through Rob's _atavide lite_ pipeline
 
 
-# If you are processing a lot of SRA runs, you will run into 16S libraries. You can screen for them with this command that works on the fastq directory
+`atavide lite` is a series of slurm scripts that run sequentially.  Notice that in the bulk of the script runs, we use the `--dependency=afterok:` to check if the previous 
+job completed correctly. If the previous job does not complete properly, the later jobs do not run. That means that this pipelines completes each step before the next one
+runs, and it is immmediately apparent when something has crashed. It is not often apparent _why_ something has crashed, but that is a problem for you to solve!
 
-```
-export NUM_R1_READS=$(wc -l R1_reads.txt | cut -f 1 -d ' ')
-mkdir -p slurm_output/sixteen_s
-sbatch --parsable --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/16S_detection_single.slurm
-```
-grep 'primary mapped' slurm_output/sixteen_s/*out | perl -ne 'm/(\d+\.\d+)\%/; print "$1\n"' | sort -g | (sed -u 10q ; echo ; tail)
-grep 'primary mapped' slurm_output/sixteen_s/*out | perl -ne 'm/(\d+\.\d+)\%/; print "$1\n"' | awk '{s+=$1} END {print s/NR}'
-```
-
-# Create a new conda environment:
+Before you being, please remove any old environments, and create the `atavide_lite` mamba environment, using the command:
 
 ```
-TMP=$(for i in {1..12}; do printf "%x" $((RANDOM % 16)); done)
-mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER//software/miniconda3/$TMP --file ../atavide_lite.yaml
-mamba activate /scratch/$PAWSEY_PROJECT/$USER//software/miniconda3/$TMP
-export ATAVIDE_CONDA=/scratch/$PAWSEY_PROJECT/$USER//software/miniconda3/$TMP
+$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh 2> /dev/null  &&  \
+    mamba env remove --prefix /scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite && \
+    mamba env remove --prefix /scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite_vamb
+mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite --file ../atavide_lite.yaml
+mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite_vamb --file ../atavide_lite_vamb.yaml
 ```
 
-# Renaming files
+This creates an `atavide_lite` and `atavide_lite_vamb` conda environments for us to use.
 
-If you download files that have only `_1.fastq.gz` or `_2.fastq.gz` and need to rename them:
+
+## 0. Get your data.
+
+We expect you to start with a directory called `fastq` that has your reads in it.
+
+## 1. Make a PAWSEY_SRC variable that will make life easier for you
+
+This is just a shortcut to make life easier for you!
+
+```
+export PAWSEY_SRC=$HOME/GitHubs/atavide_lite/pawsey_shortread
+```
+
+## 1. Create a DEFINITIONS.sh file
+
+Copy _one_ of the DEFINITIONS files to the same location as your `fastq` directory, and renamed it to DEFINITIONS.sh. 
+
+We have several examples:
+    - DEFINITIONS_human.sh - removes human genomes
+    - DEFINITIONS_shark.sh - removes shark genomes
+    - DEFINITIONS_mouse.sh - removes mouse genomes
+    - DEFINITIONS_nohost.sh - does not do any host genome removal
+
+If you have a different host to remove, I'm sure you can use one of those as a template!
+
+We also have a `sample name` variable in that file, which we use in some of the processing.
+
+For example, to remove human DNA you can do:
+
+```
+cp $PAWSEY_SRC/DEFINITIONS_human.sh DEFINITIONS.sh
+nano DEFINITIONS.sh
+```
+
+
+# 2. Check the names of your files.
+
+We need to be consistent with the names of our files, so we start by looking at the file names.
+
+Sometimes, the files are called `XXXX_R1.fastq.gz` and `XXXX_R2.fastq.gz`, sometimes they are called `XXXX_R1_001.fastq.gz` and `XXXX_R2_001.fastq.gz`, and
+sometimes they are called things like `XXXX_L001_R1.fastq.gz` and `XXXX_L0001.R2.fastq.gz`.
+
+Take a look at your fastq files, and decide where you want to trim the name off. Use `nano` to edit the DEFINITIONS.sh file and change the file ending. We will
+trim that off all files.
+
+If you download files that have only `_1.fastq.gz` or `_2.fastq.gz` and need to rename them, because we rely on having `R1` and `R2` in the file names.
 
 ```
 for F in *_1.fastq.gz; do mv $F ${F/_1/_R1}; done
 for F in *_2.fastq.gz; do mv $F ${F/_2/_R2}; done
 ```
 
+## 3. Create an R1_reads.txt file and a NUM_R1_READS variable
 
-# All commands in one go:
+Since you have paired end files, we only use the `R1` reads, but use that to get the name of the `R2` reads. The NUM_R1_READS is
+used the array jobs where we process each read separately.
+
+```
+find fastq -name \*_R1\* -printf "%f\n" > R1_reads.txt
+export NUM_R1_READS=$(wc -l R1_reads.txt | cut -f 1 -d ' ')
+echo "There are $NUM_R1_READS samples to process"
+```
+
+## 4. Create the output directorys for the slurm scripts.
+
+This just keeps the output tidy!
 
 ```
 mkdir -p slurm_output/host_slurm  slurm_output/megahit_slurm  slurm_output/mmseqs_slurm  slurm_output/vamb_slurm slurm_output/fastp_slurm
-find fastq -name \*_R1\* -printf "%f\n" > R1_reads.txt
-export NUM_R1_READS=$(wc -l R1_reads.txt | cut -f 1 -d ' ')
-echo $NUM_R1_READS
+```
 
-SRC=~/atavide_lite/deepthought_shortread
-PAWSEY_SRC=~/atavide_lite/pawsey_shortread
+## 5. Download some databases
 
-cp $SRC/DEFINITIONS.sh .
+We are nearly ready to process the data, but we need some databases like the human genome, the UniRef50 or UniRef100 databases, and so on. We 
+can download those simultaneously using the cluster:
 
-# edit the DEFINITIONS file to change the sample name
-
+```
 HUMANDLDJOB=$(sbatch --parsable $PAWSEY_SRC/download_human.slurm)
 TAXDLDJOB=$(sbatch --parsable $PAWSEY_SRC/download_taxon_db.slurm)
-UNIREFJOB=$(sbatch --parsable --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/download_uniref50.slurm)
-UNIREF100JOB=$(sbatch --parsable --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/download_uniref100.slurm)
+UNIREFJOB=$(sbatch --parsable $PAWSEY_SRC/download_uniref50.slurm)
+UNIREF100JOB=$(sbatch --parsable $PAWSEY_SRC/download_uniref100.slurm)
 VAMB_INSTALL=$(sbatch --parsable $PAWSEY_SRC/vamb_install.slurm)
+```
 
-JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/fastp.slurm)
-HOSTJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$JOB --dependency=afterok:$HUMANDLDJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/host_removal.slurm)
-MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/megahit_hostremoved.slurm)
-sbatch --parsable --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/16S_detection_single.slurm
-FAJOB=$(sbatch --parsable --dependency=afterok:$HOSTJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/fastq2fasta.slurm)
-MMSEQSJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB --dependency=afterok:$UNIREFJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/mmseqs_easy_taxonomy.slurm)
-MMSEQS100JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB --dependency=afterok:$UNIREF100JOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/mmseqs_easy_taxonomy100.slurm)
-sbatch --dependency=afterok:$MMSEQSJOB --dependency=afterok:$TAXDLDJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/mmseqs_summarise_taxonomy.slurm
-SSJOB=$(sbatch --parsable --dependency=afterok:$MMSEQSJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA   $PAWSEY_SRC/mmseqs_add_subsystems_taxonomy_fast.slurm)
+I would wait until those databases have downloaded before continuing, however you can also do the first (quality control) step because it doesn't require a database.
+
+If you are using a different host genome, of course omit the human genome download (the first slurm command here), and download your genome instead.
+
+
+## 6. Quailty control of the data
+
+We use `fastp` for quality control of the data:
+
+```
+JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 $PAWSEY_SRC/fastp.slurm)
+```
+
+## 7. Remove the host DNA
+
+`host_removal` uses whatever is defined in the DEFINITIONS.sh file, be it human, mouse, shark, or ...
+
+```
+HOSTJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$JOB $PAWSEY_SRC/host_removal.slurm)
+```
+
+## 8. Assemble the host removed sequences
+
+We use these assemblies, e.g. for binning with VAMB. The assemblies are not used in the rest of the read based annotations, so you don't need to wait for this
+to complete before submitting the subsequent jobs.
+
+```
+MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/megahit_hostremoved.slurm)
+```
+
+## 9. Convert to fasta.
+
+Please switch to the `atavide_lite` directory and make the executables before you run this step.
+
+```
+pushd $HOME/GitHubs/atavide_lite/bin
+make all
+popd
+```
+
+```
+FAJOB=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/fastq2fasta.slurm)
+```
+
+
+## 10. Run mmseqs.
+
+Note, that initially I was using UniRef50, however I currently use UniRef 100 which gives more hits. Please read [this comparison of UniRef50 vs UniRef100](https://fame.flinders.edu.au/blog/2026/05/24/uniprot) for more discussion and comparisons.
+
+For UniRef50:
+
+```
+MMSEQSJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB $PAWSEY_SRC/mmseqs_easy_taxonomy.slurm)
+```
+
+For UniRef100:
+
+```
+MMSEQS100JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB $PAWSEY_SRC/mmseqs_easy_taxonomy100.slurm)
+```
+
+> Note:
+> Currently the UniRef100 output is in a directory called `mmseqs_uniref100/mmseqs` so that you can run both UniRef50 and UniRef100. If you only run the UniRef100 analysis 
+> (which you probably should) then just move the `mmseqs` directory up to your working directory. e.g. `mv `mmseqs_uniref100/mmseqs ./`
+
+## 11. Summarise the taxonomy from the mmseqs output files
+
+This creates the `taxonomy` and `taxonomy_summary` directories with tables of taxa.
+
+```
+sbatch --dependency=afterok:$MMSEQSJOB $PAWSEY_SRC/mmseqs_summarise_taxonomy.slurm
+```
+
+## 12. Add the subsystems and count them
+
+This creates the `subsystems` directory with tables of subsystem counts
+
+```
+SSJOB=$(sbatch --parsable --dependency=afterok:$MMSEQSJOB --array=1-$NUM_R1_READS:1 $PAWSEY_SRC/mmseqs_add_subsystems_taxonomy_fast.slurm)
 COUNTSSJOB=$(sbatch --parsable --dependency=afterok:$SSJOB $PAWSEY_SRC/count_subsystems.slurm)
+```
+
+## 13. Create the data for a sankey plot or other comparisons.
+
+I like the Sankey plots to visualise where the data went, and also to check that the analysis doesn't throw up unexpected errors. Take a look in the `sankey_plot.txt` output file 
+created by this command for directions on how to make the figure.
+
+```
 SANKEYJOB=$(sbatch --parsable --dependency=afterok:$COUNTSSJOB $PAWSEY_SRC/sankey_plot.slurm)
+```
 
-# If you don't need the human / tax / uniref download
+## 14. Counting 16S genes
 
-JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/fastp.slurm)
-HOSTJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$JOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/host_removal.slurm)
-MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/megahit_hostremoved.slurm)
-sbatch --parsable --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/16S_detection_single.slurm
-FAJOB=$(sbatch --parsable --dependency=afterok:$HOSTJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/fastq2fasta.slurm)
-MMSEQSJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/mmseqs_easy_taxonomy.slurm)
-MMSEQS100JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/mmseqs_easy_taxonomy100.slurm)
-sbatch --dependency=afterok:$MMSEQSJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/mmseqs_summarise_taxonomy.slurm
-SSJOB=$(sbatch --parsable --dependency=afterok:$MMSEQSJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA   $PAWSEY_SRC/mmseqs_add_subsystems_taxonomy_fast.slurm)
-COUNTSSJOB=$(sbatch --parsable --dependency=afterok:$SSJOB $PAWSEY_SRC/count_subsystems.slurm)
-SANKEYJOB=$(sbatch --parsable --dependency=afterok:$COUNTSSJOB $PAWSEY_SRC/sankey_plot.slurm)
+If you are processing data from the SRA, you will run undoubtedly into 16S libraries. You can screen for them with this command that works on the fastq directory
 
-MEGAHITJOB=$(sbatch  --parsable --dependency=afterok:$HOSTJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/megahit.slurm)
+```
+sbatch --parsable $PAWSEY_SRC/16S_detection_single.slurm
+```
 
-# Using VAMB to bin reads.
+Once the counting has finished you can see how many 16S hits there are with:
+
+```
+grep 'primary mapped' slurm_output/sixteen_s/*out | perl -ne 'm/(\d+\.\d+)\%/; print "$1\n"' | sort -g | (sed -u 10q ; echo ; tail)
+grep 'primary mapped' slurm_output/sixteen_s/*out | perl -ne 'm/(\d+\.\d+)\%/; print "$1\n"' | awk '{s+=$1} END {print s/NR}'
+```
+
+## 15. VAMB
+
+Please note: this section of the README needs some improvement, because I have not used the different pieces in a while.
+
+### Using VAMB to bin reads.
 
 Note: if you used the megahit_host_removed the output will be in megahit_all_reads. We cheat, and move that into a directory called `megahit` so we have
 `megahit/megahit_all_reads/contigs.fna` as our input file before we continue.
 
+The normal way to use vamb is these three commands:
 
-## use this code for UNGROUPED data
-VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_concat.slurm)
-VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_minimap.slurm)
-VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJECT}-gpu /home/edwa0468/atavide_lite/pawsey_shortread/vamb.slurm)
+```
+VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB $PAWSEY_SRC/vamb_concat.slurm)
+VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_R1_READS:1 $PAWSEY_SRC/vamb_minimap.slurm)
+VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJECT}-gpu $HOME/atavide_lite/pawsey_shortread/vamb.slurm)
 
-CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/checkm.slurm vamb/bins/ vamb/checkm)
-
-
-> sbatch ~/GitHubs/atavide_lite/pawsey_shortread/vamb_mags.slurm 
+CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB $PAWSEY_SRC/checkm.slurm vamb/bins/ vamb/checkm)
+```
 
 
-## use this code for GROUPED data
-VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_concat_group.slurm samples.tsv)
-VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_minimap_group.slurm samples.tsv)
-# This is a santiy check. All the files should be the same length in each directory (but not between directories)
-# Note: the commit #b570609 has fixed the issue with inconsistent BAM files which was caused by minimap2 using multi-indexed files and so not properly including the headers
-find vamb_groups/ -name \*.bam | while read -r BAM; do L=$(samtools view -H $BAM | wc -l); echo -e "$L\t$BAM"; done
-VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJECT}-gpu $PAWSEY_SRC/vamb_group.slurm
-sbatch  ~/GitHubs/atavide_lite/pawsey_shortread/vamb_mags_group.slurm samples.tsv
-
-## Use this code for CROSSASSEMBLY data
+### Use this code for CROSSASSEMBLY data
 
 <summary>
 About the cross-assembly approach
@@ -123,28 +242,55 @@ Then we use the usual VAMB approach to bin the contigs.
 </summary>
 
 
+Assemble using the `megahit_hostremoved.slurm` script above. This will take a while to run, so do it early! Also note that `megahit` can continue if it is interuppted. Make sure the `--continue` flag is active 
+in the `megahit_hostremoved.slurm` script.
 
+```
+VCRJOB=$(sbatch --parsable $PAWSEY_SRC/vamb_concat_crass.slurm samples.tsv)
+VMJOB=$(sbatch --parsable  --dependency=afterok:$VCRJOB --array=1-$NUM_R1_READS:1 $PAWSEY_SRC/vamb_minimap_crass.slurm samples.tsv)
+```
 
-> assemble using the `megahit_hostremoved.slurm` script above. This will take a while to run, so do it early!
+#### Sanity check
 
-VCRJOB=$(sbatch --parsable  --export ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_concat_crass.slurm samples.tsv)
-VMJOB=$(sbatch --parsable  --dependency=afterok:$VCRJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_minimap_crass.slurm samples.tsv)
-# This is a santiy check. All the files should be the same length in each directory (but not between directories)
-# Note: the commit #b570609 has fixed the issue with inconsistent BAM files which was caused by minimap2 using multi-indexed files and so not properly including the headers
+All the files should be the same length in each directory (but not between directories)
+
+```
 find vamb_crass/ -name \*.bam | while read -r BAM; do L=$(samtools view -H $BAM | wc -l); echo -e "$L\t$BAM"; done
+```
+
+Then run the rest of vamb:
+
+```
 VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJECT}-gpu $PAWSEY_SRC/vamb_crass.slurm)
 sbatch  --dependency=afterok:$VAMBJOB  ~/GitHubs/atavide_lite/pawsey_shortread/vamb_mags_group.slurm samples.tsv
-
-
-CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/checkm.slurm vamb/bins/ vamb/checkm)
-
+CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB $PAWSEY_SRC/checkm.slurm vamb/bins/ vamb/checkm)
 ```
 
 
-Note: Even with the _fast_ implementation of adding functions to taxonomy, there is still an issue with the code timing out. You can rerun the code
-and it will read the last results and then continue from there.
+## All the commands in one go.
 
-Check for failed jobs:
+You can, in fact, copy and paste all the commands in one go, once you have the databases installed. If something breaks, it will stop at that point, and you'll need to look in the `slurm` output
+directory to find the error.
+
+
+```
+JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 $PAWSEY_SRC/fastp.slurm)
+HOSTJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$JOB $PAWSEY_SRC/host_removal.slurm)
+MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/megahit_hostremoved.slurm)
+sbatch --parsable $PAWSEY_SRC/16S_detection_single.slurm
+FAJOB=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/fastq2fasta.slurm)
+MMSEQSJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB $PAWSEY_SRC/mmseqs_easy_taxonomy.slurm)
+MMSEQS100JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB $PAWSEY_SRC/mmseqs_easy_taxonomy100.slurm)
+sbatch --dependency=afterok:$MMSEQSJOB $PAWSEY_SRC/mmseqs_summarise_taxonomy.slurm
+SSJOB=$(sbatch --parsable --dependency=afterok:$MMSEQSJOB --array=1-$NUM_R1_READS:1 $PAWSEY_SRC/mmseqs_add_subsystems_taxonomy_fast.slurm)
+COUNTSSJOB=$(sbatch --parsable --dependency=afterok:$SSJOB $PAWSEY_SRC/count_subsystems.slurm)
+SANKEYJOB=$(sbatch --parsable --dependency=afterok:$COUNTSSJOB $PAWSEY_SRC/sankey_plot.slurm)
+```
+
+## Failed jobs
+
+One of the most common failures is the script taking too long. You can find those, for example if the mmseqs step failed, like this:
+
 
 ```
 grep CANCELLED slurm_output/mmseqs_slurm/*err
@@ -153,5 +299,5 @@ grep CANCELLED slurm_output/mmseqs_slurm/*err
 Rerun just the failed jobs (in this example, it was #3 and 18 that failed to finish):
 
 ```
-SSJOB=$(sbatch --parsable  --array=3,18 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA   $PAWSEY_SRC/mmseqs_add_subsystems_taxonomy_fast.slurm)
+SSJOB=$(sbatch --parsable  --array=3,18 $PAWSEY_SRC/mmseqs_add_subsystems_taxonomy_fast.slurm)
 ```

--- a/pawsey_shortread/README.md
+++ b/pawsey_shortread/README.md
@@ -164,7 +164,7 @@ MMSEQS100JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:
 
 > Note:
 > Currently the UniRef100 output is in a directory called `mmseqs_uniref100/mmseqs` so that you can run both UniRef50 and UniRef100. If you only run the UniRef100 analysis 
-> (which you probably should) then just move the `mmseqs` directory up to your working directory. e.g. `mv `mmseqs_uniref100/mmseqs ./`
+> (which you probably should) then just move the `mmseqs` directory up to your working directory. e.g. `mv mmseqs_uniref100/mmseqs ./`
 
 ## 11. Summarise the taxonomy from the mmseqs output files
 

--- a/pawsey_shortread/README.md
+++ b/pawsey_shortread/README.md
@@ -93,6 +93,7 @@ VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB --export=ATAVIDE_COND
 VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_minimap.slurm)
 VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJECT}-gpu /home/edwa0468/atavide_lite/pawsey_shortread/vamb.slurm)
 
+CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/checkm.slurm vamb/bins/ vamb/checkm)
 
 
 > sbatch ~/GitHubs/atavide_lite/pawsey_shortread/vamb_mags.slurm 
@@ -135,7 +136,7 @@ VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJ
 sbatch  --dependency=afterok:$VAMBJOB  ~/GitHubs/atavide_lite/pawsey_shortread/vamb_mags_group.slurm samples.tsv
 
 
-CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $SRC/checkm.slurm vamb/bins/ vamb/checkm)
+CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA  $PAWSEY_SRC/checkm.slurm vamb/bins/ vamb/checkm)
 
 ```
 

--- a/pawsey_shortread/README.md
+++ b/pawsey_shortread/README.md
@@ -82,11 +82,20 @@ SANKEYJOB=$(sbatch --parsable --dependency=afterok:$COUNTSSJOB $PAWSEY_SRC/sanke
 
 MEGAHITJOB=$(sbatch  --parsable --dependency=afterok:$HOSTJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/megahit.slurm)
 
+# Using VAMB to bin reads.
+
+Note: if you used the megahit_host_removed the output will be in megahit_all_reads. We cheat, and move that into a directory called `megahit` so we have
+`megahit/megahit_all_reads/contigs.fna` as our input file before we continue.
+
+
 ## use this code for UNGROUPED data
 VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_concat.slurm)
 VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_R1_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $PAWSEY_SRC/vamb_minimap.slurm)
-VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJECT}-gpu /home/edwa0468/atavide_lite/pawsey_shortread/vamb.slurm
-sbatch ~/GitHubs/atavide_lite/pawsey_shortread/vamb_mags.slurm 
+VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --account=${PAWSEY_PROJECT}-gpu /home/edwa0468/atavide_lite/pawsey_shortread/vamb.slurm)
+
+
+
+> sbatch ~/GitHubs/atavide_lite/pawsey_shortread/vamb_mags.slurm 
 
 
 ## use this code for GROUPED data

--- a/pawsey_shortread/checkm.slurm
+++ b/pawsey_shortread/checkm.slurm
@@ -8,14 +8,18 @@
 #SBATCH -o slurm_output/checkm-%j.out
 #SBATCH -e slurm_output/checkm-%j.err
 
-if [[ -z $CHECKM_DATA_PATH ]]; then 
-	echo "Please define CHECKM_DATA_PATH with your databases" >&2; 
-	exit 1;
-fi
-
 if [[ ! -n "$ATAVIDE_CONDA" ]]; then
     echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
     exit 2;
+fi
+
+if [[ -z $CHECKM_DATA_PATH ]]; then 
+	CHECKM_DATA_PATH="$ATAVIDE_CONDA/checkm_data"
+	if [[ ! -e $CHECKM_DATA_PATH ]]; then
+		echo "Please install the checkm data (e.g. in $CHECKM_DATA_PATH) or set the variable CHECKM_DATA_PATH" >&2;
+		exit 1;
+	fi
+	echo "Using $CHECKM_DATA_PATH for checkm data!"
 fi
 
 

--- a/pawsey_shortread/checkm.slurm
+++ b/pawsey_shortread/checkm.slurm
@@ -1,0 +1,40 @@
+#!/bin/bash
+#SBATCH --job-name=checkm
+#SBATCH --time=1-0
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=128GB
+#SBATCH --partition=highmem
+#SBATCH -o slurm_output/checkm-%j.out
+#SBATCH -e slurm_output/checkm-%j.err
+
+if [[ -z $CHECKM_DATA_PATH ]]; then 
+	echo "Please define CHECKM_DATA_PATH with your databases" >&2; 
+	exit 1;
+fi
+
+if [[ ! -n "$ATAVIDE_CONDA" ]]; then
+    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
+    exit 2;
+fi
+
+
+if [[ $# -lt 2 ]]; then
+	echo "$0 <source directory> <destination directory>" >&2
+	exit 1
+fi
+
+set -euo pipefail
+eval "$(conda shell.bash hook)"
+conda activate $ATAVIDE_CONDA
+
+# this %/ removes the trailing / if there is one
+SOURCE=${1%/}
+DEST=${2%/}
+LOCALSOURCE=`basename $SOURCE`
+
+
+echo "Running checkm on $SOURCE and output in checkm"  >&2;
+checkm lineage_wf -t $SLURM_CPUS_PER_TASK $SOURCE $DEST
+checkm qa -t $SLURM_CPUS_PER_TASK $DEST/lineage.ms $DEST
+

--- a/pawsey_shortread/checkm.slurm
+++ b/pawsey_shortread/checkm.slurm
@@ -8,10 +8,15 @@
 #SBATCH -o slurm_output/checkm-%j.out
 #SBATCH -e slurm_output/checkm-%j.err
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
+
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
 
 if [[ -z $CHECKM_DATA_PATH ]]; then 
 	CHECKM_DATA_PATH="$ATAVIDE_CONDA/checkm_data"
@@ -22,15 +27,10 @@ if [[ -z $CHECKM_DATA_PATH ]]; then
 	echo "Using $CHECKM_DATA_PATH for checkm data!"
 fi
 
-
 if [[ $# -lt 2 ]]; then
 	echo "$0 <source directory> <destination directory>" >&2
 	exit 1
 fi
-
-set -euo pipefail
-eval "$(conda shell.bash hook)"
-conda activate $ATAVIDE_CONDA
 
 # this %/ removes the trailing / if there is one
 SOURCE=${1%/}

--- a/pawsey_shortread/checkm.slurm
+++ b/pawsey_shortread/checkm.slurm
@@ -18,7 +18,7 @@ eval "$(conda shell.bash hook)"
 ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
-if [[ -z $CHECKM_DATA_PATH ]]; then 
+if [[ -z ${CHECKM_DATA_PATH:-} ]]; then 
 	CHECKM_DATA_PATH="$ATAVIDE_CONDA/checkm_data"
 	if [[ ! -e $CHECKM_DATA_PATH ]]; then
 		echo "Please install the checkm data (e.g. in $CHECKM_DATA_PATH) or set the variable CHECKM_DATA_PATH" >&2;

--- a/pawsey_shortread/download_uniref100.slurm
+++ b/pawsey_shortread/download_uniref100.slurm
@@ -10,15 +10,16 @@
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
+
 CWD=`pwd`
 
 #DB can also be  UniRef100 UniRef100 GTDB etc

--- a/pawsey_shortread/download_uniref50.slurm
+++ b/pawsey_shortread/download_uniref50.slurm
@@ -10,15 +10,17 @@
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!
 
+
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
+
 CWD=`pwd`
 
 #DB can also be  UniRef50 UniRef100 GTDB etc

--- a/pawsey_shortread/fastp.slurm
+++ b/pawsey_shortread/fastp.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=fastp
-#SBATCH --time=1-0
+#SBATCH --time=0-1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32G

--- a/pawsey_shortread/fastp.slurm
+++ b/pawsey_shortread/fastp.slurm
@@ -9,12 +9,14 @@
 
 set -euo pipefail
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
 
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 if [[ ! -e R1_reads.txt ]]; then 

--- a/pawsey_shortread/fastp.slurm
+++ b/pawsey_shortread/fastp.slurm
@@ -8,9 +8,6 @@
 #SBATCH -e slurm_output/fastp_slurm/fastp-%A_%a.err
 
 set -euo pipefail
-
-
-set -euo pipefail
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
 # test we have atavide_lite conda installed, and then activate it

--- a/pawsey_shortread/fastq2fasta.slurm
+++ b/pawsey_shortread/fastq2fasta.slurm
@@ -7,16 +7,15 @@
 #SBATCH -o slurm_output/faing-%j.out
 #SBATCH -e slurm_output/faing-%j.err
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
-
 
 if [[ ! -e DEFINITIONS.sh ]]; then
 	echo "Please create a DEFINITIONS.sh file with SOURCE, FILEEND, HOSTREMOVED" >&2

--- a/pawsey_shortread/host_removal.slurm
+++ b/pawsey_shortread/host_removal.slurm
@@ -7,14 +7,14 @@
 #SBATCH -o slurm_output/host_slurm/host-%A_%a.out
 #SBATCH -e slurm_output/host_slurm/host-%A_%a.err
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 if [[ ! -e R1_reads.txt ]]; then

--- a/pawsey_shortread/megahit.slurm
+++ b/pawsey_shortread/megahit.slurm
@@ -7,13 +7,14 @@
 #SBATCH -o slurm_output/megahit_slurm/megahit-%A_%a.out
 #SBATCH -e slurm_output/megahit_slurm/megahit-%A_%a.err
 
-
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
 
 if [[ ! -e R1_reads.txt ]]; then 
 	echo "Please make a file with the R1 reads using this command:" >&2
@@ -28,10 +29,6 @@ if [[ ! -e DEFINITIONS.sh ]]; then
 fi
 
 source DEFINITIONS.sh
-
-eval "$(conda shell.bash hook)"
-conda activate $ATAVIDE_CONDA
-
 
 mkdir --parents megahit
 R1=$(head -n $SLURM_ARRAY_TASK_ID R1_reads.txt | tail -n 1)

--- a/pawsey_shortread/megahit_hostremoved.slurm
+++ b/pawsey_shortread/megahit_hostremoved.slurm
@@ -9,15 +9,15 @@
 #SBATCH -e slurm_output/megahit_slurm/%x-%j.err
 
 
+
 set -euo pipefail
-# set -eu
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
 
 if [[ ! -e DEFINITIONS.sh ]]; then
 	echo "Please create a DEFINITIONS.sh file with SOURCE, FILEEND, HOSTREMOVED" >&2
@@ -26,11 +26,7 @@ fi
 
 source DEFINITIONS.sh
 
-eval "$(conda shell.bash hook)"
-conda activate $ATAVIDE_CONDA
-
 find no_human/ -name \*${FILEEND/R1/R2}
-
 
 # Collect R1 and R2 lists
 R1_FILES=($(find $HOSTREMOVED -name \*${FILEEND} | sort))

--- a/pawsey_shortread/megahit_hostremoved.slurm
+++ b/pawsey_shortread/megahit_hostremoved.slurm
@@ -26,7 +26,7 @@ fi
 
 source DEFINITIONS.sh
 
-find no_human/ -name \*${FILEEND/R1/R2}
+find $HOSTREMOVED -name \*${FILEEND/R1/R2}
 
 # Collect R1 and R2 lists
 R1_FILES=($(find $HOSTREMOVED -name \*${FILEEND} | sort))

--- a/pawsey_shortread/megahit_hostremoved.slurm
+++ b/pawsey_shortread/megahit_hostremoved.slurm
@@ -29,13 +29,17 @@ source DEFINITIONS.sh
 eval "$(conda shell.bash hook)"
 conda activate $ATAVIDE_CONDA
 
-
+find no_human/ -name \*${FILEEND/R1/R2}
 
 
 # Collect R1 and R2 lists
-R1_FILES=($(find $HOSTREMOVED -name \*_R1.fastq.gz | sort))
-R2_FILES=($(find $HOSTREMOVED -name \*_R2.fastq.gz | sort))
-OTHER_FILES=($(find $HOSTREMOVED -name \*.fastq.gz | grep -v -E "_R[12]\.fastq\.gz" | sort)) || true
+R1_FILES=($(find $HOSTREMOVED -name \*${FILEEND} | sort))
+R2_FILES=($(find $HOSTREMOVED -name \*${FILEEND/R1/R2} | sort))
+mapfile -t OTHER_FILES < <(
+    comm -23 \
+        <(find "$HOSTREMOVED" -name "*.fastq.gz" | sort) \
+        <(find "$HOSTREMOVED" \( -name "*${FILEEND}" -o -name "*${FILEEND/R1/R2}" \) | sort)
+)
 
 # Join them into comma-separated strings
 R1_JOINED=$(IFS=,; echo "${R1_FILES[*]}")

--- a/pawsey_shortread/mmseqs_add_subsystems.slurm
+++ b/pawsey_shortread/mmseqs_add_subsystems.slurm
@@ -8,11 +8,14 @@
 #SBATCH -e slurm_output/mmseqs_slurm/mmseqs_ss-%A_%a.err
 
 
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
 
 if [[ ! -e R1_reads.txt ]]; then 
 	echo "Please make a file with the R1 reads using this command:" >&2
@@ -32,8 +35,6 @@ source DEFINITIONS.sh
 # are going to wait for the "copying_done" flag
 
 DBDIR=~/scratch_1018/uniref
-eval "$(conda shell.bash hook)"
-conda activate $ATAVIDE_CONDA
 
 if [[ $SLURM_ARRAY_TASK_ID == 1 ]]; then
 	if [ ! -e $DBDIR/copying_done ]; then

--- a/pawsey_shortread/mmseqs_add_subsystems_taxonomy_fast.slurm
+++ b/pawsey_shortread/mmseqs_add_subsystems_taxonomy_fast.slurm
@@ -7,16 +7,15 @@
 #SBATCH -o slurm_output/mmseqs_slurm/mmseqs_ss-%A_%a.out
 #SBATCH -e slurm_output/mmseqs_slurm/mmseqs_ss-%A_%a.err
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
-
 
 if [[ ! -e R1_reads.txt ]]; then 
 	echo "Please make a file with the R1 reads using this command:" >&2

--- a/pawsey_shortread/mmseqs_easy_taxonomy.slurm
+++ b/pawsey_shortread/mmseqs_easy_taxonomy.slurm
@@ -20,14 +20,14 @@
 #SBATCH -o slurm_output/mmseqs_slurm/mmseqsET-%A_%a.out
 #SBATCH -e slurm_output/mmseqs_slurm/mmseqsET-%A_%a.err
 
-eval "$(conda shell.bash hook)"
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 echo "Start " `date` >&2;
@@ -54,7 +54,7 @@ OUTDIR=mmseqs/${R/$FILEEND/}
 mkdir --parents $OUTDIR $TMPDIR
 
 # convert fastq to fasta
-# this throws an unbound error if FAFILEEND is not in DEFINITIONS
+FAFILEEND=${FILEEND/fastq/fasta}
 R1=${R/$FILEEND/$FAFILEEND}
 R2=${R1/_R1/_R2}
 OUTPUT=$OUTDIR/${R/$FILEEND/}

--- a/pawsey_shortread/mmseqs_easy_taxonomy100.slurm
+++ b/pawsey_shortread/mmseqs_easy_taxonomy100.slurm
@@ -16,7 +16,8 @@
 #SBATCH --time=1-0
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
-#SBATCH --mem=220G
+#SBATCH --mem=480G
+#SBATCH --partition=highmem
 #SBATCH -o slurm_output/mmseqs_slurm/%x-%A_%a.out
 #SBATCH -e slurm_output/mmseqs_slurm/%x-%A_%a.err
 
@@ -67,10 +68,10 @@ fi
 
 # cp fasta/$R1 fasta/$R2 $BGFS
 
-echo "Running  mmseqs easy-taxonomy fasta/$R1 fasta/$R2 $DBSOURCE/$DB $OUTPUT $(mktemp -d -p $TMPDIR) --threads 64" >&2;
-mmseqs easy-taxonomy fasta/$R1 fasta/$R2 $DBSOURCE/$DB $OUTPUT $(mktemp -d -p $TMPDIR) --threads 64
+echo "Running  mmseqs easy-taxonomy fasta/$R1 fasta/$R2 $DBSOURCE/$DB $OUTPUT $(mktemp -d -p $TMPDIR) --threads $SLURM_CPUS_PER_TASK" >&2;
+mmseqs easy-taxonomy fasta/$R1 fasta/$R2 $DBSOURCE/$DB $OUTPUT $(mktemp -d -p $TMPDIR) --threads $SLURM_CPUS_PER_TASK
 
-find $OUTDIR -type f  | parallel -j 32 gzip
+find $OUTDIR -type f  | parallel -j $SLURM_CPUS_PER_TASK gzip
 
 echo "Fin " `date` >&2;
 

--- a/pawsey_shortread/mmseqs_easy_taxonomy100.slurm
+++ b/pawsey_shortread/mmseqs_easy_taxonomy100.slurm
@@ -21,14 +21,14 @@
 #SBATCH -o slurm_output/mmseqs_slurm/%x-%A_%a.out
 #SBATCH -e slurm_output/mmseqs_slurm/%x-%A_%a.err
 
-eval "$(conda shell.bash hook)"
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 echo "Start " `date` >&2;
@@ -55,7 +55,7 @@ OUTDIR=mmseqs_uniref100/mmseqs/${R/$FILEEND/}
 mkdir --parents $OUTDIR $TMPDIR
 
 # convert fastq to fasta
-# this throws an unbound error if FAFILEEND is not in DEFINITIONS
+FAFILEEND=${FILEEND/fastq/fasta}
 R1=${R/$FILEEND/$FAFILEEND}
 R2=${R1/_R1/_R2}
 OUTPUT=$OUTDIR/${R/$FILEEND/}

--- a/pawsey_shortread/mmseqs_summarise_taxonomy.slurm
+++ b/pawsey_shortread/mmseqs_summarise_taxonomy.slurm
@@ -8,11 +8,15 @@
 #SBATCH -e slurm_output/mmtax-%j.err
 
 
+
 set -euo pipefail
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
 
 if [[ ! -e DEFINITIONS.sh ]]; then
 	echo "Please create a DEFINITIONS.sh file with SOURCE, FILEEND, HOSTREMOVED" >&2
@@ -20,9 +24,6 @@ if [[ ! -e DEFINITIONS.sh ]]; then
 fi
 
 source DEFINITIONS.sh
-
-eval "$(conda shell.bash hook)"
-conda activate $ATAVIDE_CONDA
 
 snakemake --profile slurm -s ~/GitHubs/atavide_lite/summarise_taxonomy/taxonomy.smk
 python ~/GitHubs/atavide_lite/summarise_taxonomy/scripts/join_taxonomies.py -t taxonomy -o taxonomy_summary/ -n $SAMPLENAME

--- a/pawsey_shortread/vamb.slurm
+++ b/pawsey_shortread/vamb.slurm
@@ -8,15 +8,14 @@
 #SBATCH --gres=gpu:8
 #SBATCH --partition=gpu-dev
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 # Please see the vamb_install.slurm script to create the 

--- a/pawsey_shortread/vamb.slurm
+++ b/pawsey_shortread/vamb.slurm
@@ -22,7 +22,7 @@ conda activate $ATAVIDE_CONDA
 # virtual environment for vamb. NOTE: Do not use conda to install vamb, because 
 # we need a rcom install, not nvidia.
 
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/vamb"
+VENV_DIR="/scratch/$PAWSEY_PROJECT/$USER/software/pip/vamb"
 if [[ ! -e "$VENV_DIR" ]]; then 
 	echo "Please run vamb_install.slurm to create the vamb virtual environment" >&2
 	exit 1;

--- a/pawsey_shortread/vamb.slurm
+++ b/pawsey_shortread/vamb.slurm
@@ -1,17 +1,26 @@
 #!/bin/bash
 #SBATCH --job-name=VAMB
-#SBATCH --time=1-0
+#SBATCH --time=0-4
 #SBATCH --ntasks=1
 #SBATCH --nodes=1
 #SBATCH -o slurm_output/vamb_slurm/vamb-%j.out
 #SBATCH -e slurm_output/vamb_slurm/vamb-%j.err
 #SBATCH --gres=gpu:8
-#SBATCH --partition=gpu
+#SBATCH --partition=gpu-dev
 
 set -euo pipefail
 
+
+if [[ ! -n "$ATAVIDE_CONDA" ]]; then
+    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
+    exit 2;
+fi
+
+eval "$(conda shell.bash hook)"
+conda activate $ATAVIDE_CONDA
+
 # Please see the vamb_install.slurm script to create the 
-# virtual environment for vamb. NOTE: Do not use conda, because 
+# virtual environment for vamb. NOTE: Do not use conda to install vamb, because 
 # we need a rcom install, not nvidia.
 
 VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/vamb"
@@ -48,13 +57,13 @@ for R1 in $(sort -R R1_reads.txt); do
 	echo "R1: $R2 BAM: $BAM" >&2;
 	if [[ ! -e $OUTDIR/mapped_reads/$BAM ]]; then
 		echo "Bam file: '$OUTDIR/mapped_reads/$BAM' not found. Data generated" >&2;
-		minimap2 -t 16 -N 5 -ax sr $OUTDIR/contigs.mmi --split-prefix mmsplit$$ $HOSTREMOVED/$R1 $HOSTREMOVED/$R2 | samtools view -F 3584 -b --threads 16  | samtools sort -@ 16 -o $OUTDIR/mapped_reads/$BAM -
+		# minimap2 -t 16 -N 5 -ax sr $OUTDIR/contigs.mmi --split-prefix mmsplit$$ $HOSTREMOVED/$R1 $HOSTREMOVED/$R2 | samtools view -F 3584 -b --threads 16  | samtools sort -@ 16 -o $OUTDIR/mapped_reads/$BAM -
 	fi
 done
 
 
 
-vamb -o C -p 16 --cuda --outdir $OUTDIR/vamb --fasta $OUTDIR/contigs.fna.gz --bamdir $OUTDIR/mapped_reads/
+vamb bin default -o C -p $SLURM_CPUS_PER_TASK --cuda --outdir $OUTDIR/vamb --fasta $OUTDIR/contigs.fna.gz --bamdir $OUTDIR/mapped_reads/
 python ~/atavide_lite/bin/vamb_create_fasta.py $OUTDIR/contigs.fna.gz $OUTDIR/vamb/vae_clusters_unsplit.tsv 20000 $OUTDIR/bins &
 python ~/atavide_lite/bin/vamb_create_fasta.py $OUTDIR/contigs.fna.gz $OUTDIR/vamb/vae_clusters_split.tsv 20000 $OUTDIR/bins &
 wait

--- a/pawsey_shortread/vamb.slurm
+++ b/pawsey_shortread/vamb.slurm
@@ -55,8 +55,7 @@ for R1 in $(sort -R R1_reads.txt); do
 	BAM=${R1/$FILEEND/.bam}
 	echo "R1: $R2 BAM: $BAM" >&2;
 	if [[ ! -e $OUTDIR/mapped_reads/$BAM ]]; then
-		echo "Bam file: '$OUTDIR/mapped_reads/$BAM' not found. Data generated" >&2;
-		# minimap2 -t 16 -N 5 -ax sr $OUTDIR/contigs.mmi --split-prefix mmsplit$$ $HOSTREMOVED/$R1 $HOSTREMOVED/$R2 | samtools view -F 3584 -b --threads 16  | samtools sort -@ 16 -o $OUTDIR/mapped_reads/$BAM -
+		echo "Bam file: '$OUTDIR/mapped_reads/$BAM' not found. Please check if you want that file" >&2;
 	fi
 done
 

--- a/pawsey_shortread/vamb_concat.slurm
+++ b/pawsey_shortread/vamb_concat.slurm
@@ -9,13 +9,14 @@
 
 set -euo pipefail
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
+VENV_DIR="/scratch/$PAWSEY_ACCOUNT/$USER/software/pip/vamb"
+if [[ ! -e "$VENV_DIR" ]]; then 
+	echo "Please run vamb_install.slurm to create the vamb virtual environment" >&2
+	exit 1;
 fi
 
-eval "$(conda shell.bash hook)"
-conda activate $ATAVIDE_CONDA
+module load rocm/6.2.4
+source "$VENV_DIR/bin/activate"
 
 mkdir -p vamb
 python ~/atavide_lite/bin/vamb_concatenate.py -m 300 vamb/contigs.fna.gz megahit/*/final.contigs.fa

--- a/pawsey_shortread/vamb_concat_crass.slurm
+++ b/pawsey_shortread/vamb_concat_crass.slurm
@@ -10,7 +10,15 @@
 # we use cross assembly of all samples using megahit, and then map the reads on a per group
 # basis
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
 
 VENV_DIR="/scratch/$PAWSEY_ACCOUNT/$USER/software/pip/vamb"
 if [[ ! -e "$VENV_DIR" ]]; then 
@@ -36,8 +44,6 @@ fi
 
 source DEFINITIONS.sh
 
-eval "$(conda shell.bash hook)"
-conda activate $ATAVIDE_CONDA
 
 # run vamb_concat 
 # we want a tsv file with [category] [sample]

--- a/pawsey_shortread/vamb_concat_group.slurm
+++ b/pawsey_shortread/vamb_concat_group.slurm
@@ -9,10 +9,14 @@
 
 set -euo pipefail
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
+VENV_DIR="/scratch/$PAWSEY_ACCOUNT/$USER/software/pip/vamb"
+if [[ ! -e "$VENV_DIR" ]]; then 
+	echo "Please run vamb_install.slurm to create the vamb virtual environment" >&2
+	exit 1;
 fi
+
+module load rocm/6.2.4
+source "$VENV_DIR/bin/activate"
 
 if [[ ! -e R1_reads.txt ]]; then 
 	echo "Please make a file with the R1 reads using this command:" >&2

--- a/pawsey_shortread/vamb_concat_group.slurm
+++ b/pawsey_shortread/vamb_concat_group.slurm
@@ -11,11 +11,6 @@
 set -euo pipefail
 trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-# test we have atavide_lite conda installed, and then activate it
-eval "$(conda shell.bash hook)"
-"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
-ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
-
 VENV_DIR="/scratch/$PAWSEY_ACCOUNT/$USER/software/pip/vamb"
 if [[ ! -e "$VENV_DIR" ]]; then 
 	echo "Please run vamb_install.slurm to create the vamb virtual environment" >&2
@@ -38,8 +33,6 @@ if [[ ! -e DEFINITIONS.sh ]]; then
 fi
 
 source DEFINITIONS.sh
-
-conda activate $ATAVIDE_CONDA
 
 # run vamb_concat 
 # we want a tsv file with [category] [sample]

--- a/pawsey_shortread/vamb_concat_group.slurm
+++ b/pawsey_shortread/vamb_concat_group.slurm
@@ -7,7 +7,14 @@
 #SBATCH -o slurm_output/vamb_slurm/vamb_concat-%j.out
 #SBATCH -e slurm_output/vamb_slurm/vamb_concat-%j.err
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 
 VENV_DIR="/scratch/$PAWSEY_ACCOUNT/$USER/software/pip/vamb"
 if [[ ! -e "$VENV_DIR" ]]; then 
@@ -32,7 +39,6 @@ fi
 
 source DEFINITIONS.sh
 
-eval "$(conda shell.bash hook)"
 conda activate $ATAVIDE_CONDA
 
 # run vamb_concat 

--- a/pawsey_shortread/vamb_crass.slurm
+++ b/pawsey_shortread/vamb_crass.slurm
@@ -14,7 +14,7 @@ set -uo pipefail
 # virtual environment for vamb. NOTE: Do not use conda, because 
 # we need a rcom install, not nvidia.
 
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/vamb"
+VENV_DIR="/scratch/$PAWSEY_PROJECT/$USER/software/pip/vamb"
 if [[ ! -e "$VENV_DIR" ]]; then 
 	echo "Please run vamb_install.slurm to create the vamb virtual environment" >&2
 	exit 1;

--- a/pawsey_shortread/vamb_group.slurm
+++ b/pawsey_shortread/vamb_group.slurm
@@ -14,7 +14,7 @@ set -uo pipefail
 # virtual environment for vamb. NOTE: Do not use conda, because 
 # we need a rcom install, not nvidia.
 
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/vamb"
+VENV_DIR="/scratch/$PAWSEY_PROJECT/$USER/software/pip/vamb"
 if [[ ! -e "$VENV_DIR" ]]; then 
 	echo "Please run vamb_install.slurm to create the vamb virtual environment" >&2
 	exit 1;

--- a/pawsey_shortread/vamb_install.slurm
+++ b/pawsey_shortread/vamb_install.slurm
@@ -42,7 +42,7 @@ set -euo pipefail
 module load rocm/6.2.4
 
 # ---- 2) Create and load the virtual environment 
-VENV_DIR="/scratch/pawsey1018/edwa0468/software/pip/vamb"
+VENV_DIR="/scratch/$PAWSEY_ACCOUNT/$USER/software/pip/vamb"
 if [[ -e "$VENV_DIR" ]]; then 
 	rm -rf "$VENV_DIR"
 fi

--- a/pawsey_shortread/vamb_install.slurm
+++ b/pawsey_shortread/vamb_install.slurm
@@ -31,6 +31,8 @@
 # torch 2.6.0, rocm 6.2.4 python 3.12.
 #
 #
+#
+# Note 2: vamb requires pytorch 2.6.0 which requires python3.11 or python3.12!
 
 
 
@@ -46,7 +48,7 @@ if [[ -e "$VENV_DIR" ]]; then
 fi
 
 mkdir -p "$VENV_DIR"
-python -m venv "$VENV_DIR"
+python3.12 -m venv "$VENV_DIR"
 source "$VENV_DIR/bin/activate"
 
 # Upgrade packaging tooling

--- a/pawsey_shortread/vamb_minimap.slurm
+++ b/pawsey_shortread/vamb_minimap.slurm
@@ -1,6 +1,6 @@
 #!/bin/bash
 #SBATCH --job-name=VAMB
-#SBATCH --time=5-0
+#SBATCH --time=1-0
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
 #SBATCH --mem=128G

--- a/pawsey_shortread/vamb_minimap.slurm
+++ b/pawsey_shortread/vamb_minimap.slurm
@@ -9,14 +9,14 @@
 
 # Just the minimap section of VAMB which does not require GPUs and we can do in parallel
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 if [[ ! -e DEFINITIONS.sh ]]; then
@@ -47,8 +47,9 @@ if [[ ! -e $OUTDIR/mapped_reads/$BAM ]]; then
 		minimap2 -I100G -d $OUTDIR/contigs.mmi $OUTDIR/contigs.fna.gz
 	fi
 
-
-	minimap2 -t $SLURM_CPUS_PER_TASK -N 5 -ax sr "$OUTDIR/contigs.mmi" --split-prefix "mmsplit$$" "$HOSTREMOVED/$R1" "$HOSTREMOVED/$R2" \
+	# note the original version had -N 5 which keeps 5 secondary alignments. I turned off secondary alignments because
+	# one read mapping was running really slowly!
+	minimap2 -t $SLURM_CPUS_PER_TASK --secondary=no -ax sr "$OUTDIR/contigs.mmi" --split-prefix "mmsplit$$" "$HOSTREMOVED/$R1" "$HOSTREMOVED/$R2" \
 		| samtools view -b -F 3596 --threads $SLURM_CPUS_PER_TASK | samtools sort -@ $SLURM_CPUS_PER_TASK -o "$OUTDIR/mapped_reads/$BAM" -
 
 	samtools index "$OUTDIR/mapped_reads/$BAM"

--- a/pawsey_shortread/vamb_minimap.slurm
+++ b/pawsey_shortread/vamb_minimap.slurm
@@ -1,8 +1,8 @@
 #!/bin/bash
 #SBATCH --job-name=VAMB
-#SBATCH --time=1-0
+#SBATCH --time=0-8
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=16
+#SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
 #SBATCH -o slurm_output/vamb_slurm/map_reads-%A_%a.out
 #SBATCH -e slurm_output/vamb_slurm/map_reads-%A_%a.err
@@ -47,12 +47,10 @@ if [[ ! -e $OUTDIR/mapped_reads/$BAM ]]; then
 		minimap2 -I100G -d $OUTDIR/contigs.mmi $OUTDIR/contigs.fna.gz
 	fi
 
-	# uncompress the fasta file to a temp file
-	temp_fasta=$(mktemp --suffix=.fasta)
-	gunzip -c "$INF" > "$temp_fasta"
 
-	minimap2 -t 16 -N 5 -ax sr $OUTDIR/contigs.mmi --split-prefix mmsplit$$ $HOSTREMOVED/$R1 $HOSTREMOVED/$R2 \
-		| samtools view -F 3584 --threads 16  | samtools view -b -T "$temp_fasta" | samtools sort -@ 16 -o $OUTDIR/mapped_reads/$BAM -
+	minimap2 -t $SLURM_CPUS_PER_TASK -N 5 -ax sr "$OUTDIR/contigs.mmi" --split-prefix "mmsplit$$" "$HOSTREMOVED/$R1" "$HOSTREMOVED/$R2" \
+		| samtools view -b -F 3596 --threads $SLURM_CPUS_PER_TASK | samtools sort -@ $SLURM_CPUS_PER_TASK -o "$OUTDIR/mapped_reads/$BAM" -
 
-	rm -f "$temp_fasta"
+	samtools index "$OUTDIR/mapped_reads/$BAM"
+
 fi

--- a/pawsey_shortread/vamb_minimap_crass.slurm
+++ b/pawsey_shortread/vamb_minimap_crass.slurm
@@ -11,12 +11,14 @@
 
 set -euo pipefail
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
 
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 if [[ ! -e DEFINITIONS.sh ]]; then

--- a/pawsey_shortread/vamb_minimap_group.slurm
+++ b/pawsey_shortread/vamb_minimap_group.slurm
@@ -9,14 +9,14 @@
 
 # Run the minimap section for each of the groups
 
+
 set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 
-if [[ ! -n "$ATAVIDE_CONDA" ]]; then
-    echo "Please define the ATAVIDE_CONDA environment variable with the location of your ATAVIDE_LITE conda installation" >&2;
-    exit 2;
-fi
-
+# test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
 conda activate $ATAVIDE_CONDA
 
 if [[ ! -e DEFINITIONS.sh ]]; then


### PR DESCRIPTION
This pull request makes several improvements to SLURM job scripts and documentation for metagenomic workflows. The main changes include adding support for UniRef100 database version tracking, updating resource allocations for large jobs, and making job scripts more flexible and robust.

**Resource allocation and job script improvements:**

* Increased memory allocation from 220G to 480G and set the `--partition=highmem` for `pawsey_shortread/mmseqs_easy_taxonomy100.slurm` to better support large jobs.
* Updated the number of threads for `mmseqs easy-taxonomy` and `parallel` commands to use the value of `$SLURM_CPUS_PER_TASK` instead of hardcoded values, improving flexibility and resource utilization.
* Adjusted the SLURM time limit format in `pawsey_shortread/fastp.slurm` from `1-0` to `0-1` to correct the time specification.

**Database version handling and documentation:**

* Added logic in `methods/create_methods.slurm` to detect and report the version of the UniRef100 database, similar to existing handling for UniRef50. Improved version reporting messages for clarity.
* Updated documentation in `methods/create_methods.slurm` to include instructions for using either UniRef50 or UniRef100 with MMseqs2, but marked sections for deletion to avoid confusion. [[1]](diffhunk://#diff-b92fc846c209b7f9bf8b3a0f593c258a46c8c19c221bfb70672a1b9c07fb1e0eR79-R80) [[2]](diffhunk://#diff-b92fc846c209b7f9bf8b3a0f593c258a46c8c19c221bfb70672a1b9c07fb1e0eR89-R100)