### PR TITLE
summarise PHROG function counts

### DIFF
--- a/bin/count_phrog_functions.py
+++ b/bin/count_phrog_functions.py
@@ -1,0 +1,189 @@
+"""Summarise PHROG-annotated MMseqs top-hit reports across samples."""
+
+import argparse
+import gzip
+import math
+import os
+import sys
+from collections import defaultdict
+
+
+REPORT_SUFFIX = "_tophit_report_phrog_function.tsv.gz"
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Create raw and counts-per-million PHROG summary tables"
+    )
+    parser.add_argument(
+        "-d",
+        "--directory",
+        default="mmseqs",
+        help="directory containing one MMseqs output directory per sample [mmseqs]",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        default="phrog_functions",
+        help="output directory [phrog_functions]",
+    )
+    parser.add_argument(
+        "-n", "--name", default="atavide", help="prefix for output files [atavide]"
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    return parser.parse_args()
+
+
+def add_count(counts, sample, feature, value):
+    if feature:
+        counts[feature][sample] += value
+
+
+def format_number(value):
+    return f"{value:.12g}"
+
+
+def write_matrix(path, features, samples, denominator=None):
+    with open(path, "w", encoding="utf-8") as output:
+        output.write("\t" + "\t".join(samples) + "\n")
+        for feature in sorted(features):
+            output.write(feature)
+            for sample in samples:
+                value = features[feature].get(sample, 0.0)
+                if denominator is not None:
+                    total = denominator.get(sample, 0.0)
+                    value = value * 1_000_000 / total if total > 0 else 0.0
+                output.write("\t" + format_number(value))
+            output.write("\n")
+
+
+def main():
+    args = parse_args()
+    if not os.path.isdir(args.directory):
+        raise SystemExit(f"FATAL: {args.directory} is not a directory")
+
+    phrog_counts = defaultdict(lambda: defaultdict(float))
+    annotation_counts = defaultdict(lambda: defaultdict(float))
+    category_counts = defaultdict(lambda: defaultdict(float))
+    metadata = {}
+    total_hits = defaultdict(float)
+    phrog_hits = defaultdict(float)
+    samples = []
+
+    for sample in sorted(os.listdir(args.directory)):
+        sample_directory = os.path.join(args.directory, sample)
+        if not os.path.isdir(sample_directory):
+            continue
+
+        report = os.path.join(sample_directory, sample + REPORT_SUFFIX)
+        if not os.path.isfile(report):
+            if args.verbose:
+                print(f"Skipping {sample}: {report} does not exist", file=sys.stderr)
+            continue
+
+        if args.verbose:
+            print(f"Reading {sample} from {report}", file=sys.stderr)
+        samples.append(sample)
+
+        with gzip.open(report, "rt", encoding="utf-8") as input_file:
+            for line_number, line in enumerate(input_file, start=1):
+                fields = line.rstrip("\r\n").split("\t")
+                if len(fields) != 12:
+                    raise SystemExit(
+                        f"FATAL: {report}:{line_number} has {len(fields)} columns; "
+                        "expected 12"
+                    )
+
+                try:
+                    count = float(fields[1])
+                except ValueError:
+                    raise SystemExit(
+                        f"FATAL: {report}:{line_number} has a non-numeric alignment "
+                        f"count: {fields[1]!r}"
+                    ) from None
+                if not math.isfinite(count) or count < 0:
+                    raise SystemExit(
+                        f"FATAL: {report}:{line_number} has an invalid alignment "
+                        f"count: {fields[1]!r}"
+                    )
+
+                total_hits[sample] += count
+                phrog_id, color, annotation, category = fields[8:12]
+                if not phrog_id:
+                    continue
+
+                phrog_hits[sample] += count
+                add_count(phrog_counts, sample, phrog_id, count)
+                add_count(annotation_counts, sample, annotation, count)
+                add_count(category_counts, sample, category, count)
+
+                current_metadata = (color, annotation, category)
+                if phrog_id in metadata and metadata[phrog_id] != current_metadata:
+                    raise SystemExit(
+                        f"FATAL: conflicting annotations were found for {phrog_id}"
+                    )
+                metadata[phrog_id] = current_metadata
+
+    if not samples:
+        raise SystemExit(
+            f"FATAL: no *{REPORT_SUFFIX} files were found below {args.directory}"
+        )
+
+    os.makedirs(args.output, exist_ok=True)
+    levels = {
+        "phrog": phrog_counts,
+        "annotation": annotation_counts,
+        "category": category_counts,
+    }
+    for level, counts in levels.items():
+        write_matrix(
+            os.path.join(args.output, f"{args.name}_{level}_raw.tsv"),
+            counts,
+            samples,
+        )
+        write_matrix(
+            os.path.join(args.output, f"{args.name}_{level}_norm_all.tsv"),
+            counts,
+            samples,
+            total_hits,
+        )
+        write_matrix(
+            os.path.join(args.output, f"{args.name}_{level}_norm_phrog.tsv"),
+            counts,
+            samples,
+            phrog_hits,
+        )
+
+    with open(
+        os.path.join(args.output, f"{args.name}_phrog_metadata.tsv"),
+        "w",
+        encoding="utf-8",
+    ) as output:
+        output.write("phrog_id\tcolor\tannotation\tcategory\n")
+        for phrog_id in sorted(metadata):
+            output.write(phrog_id + "\t" + "\t".join(metadata[phrog_id]) + "\n")
+
+    with open(
+        os.path.join(args.output, "README.md"), "w", encoding="utf-8"
+    ) as output:
+        output.write(
+            f"""# PHROG count tables
+
+The `{args.name}_*_raw.tsv` files contain alignment counts from column 2 of the
+MMseqs top-hit reports.
+
+The `{args.name}_*_norm_all.tsv` files contain counts per million of all MMseqs
+top hits, including hits without a PHROG match.
+
+The `{args.name}_*_norm_phrog.tsv` files contain counts per million of MMseqs
+top hits that have a PHROG match.
+
+Tables are provided by PHROG ID, annotation, and category. The
+`{args.name}_phrog_metadata.tsv` file maps each observed PHROG ID to its color,
+annotation, and category.
+"""
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/count_phrog_functions.py
+++ b/bin/count_phrog_functions.py
@@ -88,10 +88,10 @@ def main():
         with gzip.open(report, "rt", encoding="utf-8") as input_file:
             for line_number, line in enumerate(input_file, start=1):
                 fields = line.rstrip("\r\n").split("\t")
-                if len(fields) != 12:
+                if len(fields) < 2:
                     raise SystemExit(
                         f"FATAL: {report}:{line_number} has {len(fields)} columns; "
-                        "expected 12"
+                        "expected at least 2"
                     )
 
                 try:
@@ -108,6 +108,9 @@ def main():
                     )
 
                 total_hits[sample] += count
+                if len(fields) < 12:
+                    continue
+
                 phrog_id, color, annotation, category = fields[8:12]
                 if not phrog_id:
                     continue

--- a/bin/count_phrog_functions.py
+++ b/bin/count_phrog_functions.py
@@ -120,7 +120,8 @@ def main():
                 current_metadata = (color, annotation, category)
                 if phrog_id in metadata and metadata[phrog_id] != current_metadata:
                     raise SystemExit(
-                        f"FATAL: conflicting annotations were found for {phrog_id}"
+                        f"FATAL: {report}:{line_number} has conflicting annotations "
+                        f"for {phrog_id}"
                     )
                 metadata[phrog_id] = current_metadata
 

--- a/pawsey_shortread/count_phrog_functions.slurm
+++ b/pawsey_shortread/count_phrog_functions.slurm
@@ -18,6 +18,6 @@ fi
 source DEFINITIONS.sh
 : "${SAMPLENAME:?SAMPLENAME must be defined in DEFINITIONS.sh}"
 
-export PYTHONPATH="${PYTHONPATH:-}:$HOME/GitHubs/atavide_lite"
+export PYTHONPATH="${PYTHONPATH:+${PYTHONPATH}:}$HOME/GitHubs/atavide_lite"
 python "$HOME/atavide_lite/bin/count_phrog_functions.py" -d mmseqs -n "$SAMPLENAME"
 find phrog_functions -type f -name '*.tsv' -exec pigz {} +

--- a/pawsey_shortread/count_phrog_functions.slurm
+++ b/pawsey_shortread/count_phrog_functions.slurm
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH --job-name=CountPHROG
+#SBATCH --time=0-1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=16G
+#SBATCH -o slurm_output/count_phrog-%j.out
+#SBATCH -e slurm_output/count_phrog-%j.err
+
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line $LINENO: $BASH_COMMAND" >&2; exit $s' ERR
+
+if [[ ! -f DEFINITIONS.sh ]]; then
+	echo "Please create a DEFINITIONS.sh file with SAMPLENAME" >&2
+	exit 2
+fi
+
+source DEFINITIONS.sh
+: "${SAMPLENAME:?SAMPLENAME must be defined in DEFINITIONS.sh}"
+
+export PYTHONPATH="${PYTHONPATH:-}:$HOME/GitHubs/atavide_lite"
+python "$HOME/atavide_lite/bin/count_phrog_functions.py" -d mmseqs -n "$SAMPLENAME"
+find phrog_functions -type f -name '*.tsv' -exec pigz {} +


### PR DESCRIPTION
## Summary

- add a SLURM wrapper modeled on `count_subsystems.slurm` for aggregating PHROG-enriched MMseqs reports
- generate raw and counts-per-million matrices by PHROG ID, annotation, and category
- normalize against both all MMseqs hits and PHROG-matched hits, and retain observed PHROG metadata
- validate report shape and alignment counts with file-and-line error reporting

## Outputs

The job writes tables under `phrog_functions/`, prefixes them with `SAMPLENAME`, and compresses the TSV outputs with `pigz`.

## Validation

- `bash -n pawsey_shortread/count_phrog_functions.slurm`
- `python -m py_compile bin/count_phrog_functions.py` with bytecode directed to `/tmp`
- two-sample synthetic test covering matched and unmatched hits
- assertions for raw, all-hit CPM, and PHROG-hit CPM values
- `git diff --check`

`shellcheck` and `black` were unavailable in the environment.
