### PR TITLE
More updates

### DIFF
--- a/pawsey_minion/README.md
+++ b/pawsey_minion/README.md
@@ -129,7 +129,7 @@ We use these assemblies, e.g. for binning with VAMB. The assemblies are not used
 to complete before submitting the subsequent jobs.
 
 ```
-MEGAHITJOB=$(sbatch  --parsable --dependency=afterok:$HOSTJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA --array=1-$NUM_READS:1 $SRC/megahit.slurm)
+MEGAHITJOB=$(sbatch  --parsable --dependency=afterok:$HOSTJOB --array=1-$NUM_READS:1 $SRC/megahit.slurm)
 ```
 
 ## 9. Convert to fasta.
@@ -187,10 +187,10 @@ SANKEYJOB=$(sbatch --parsable --dependency=afterok:$COUNTSSJOB $SRC/sankey_plot.
 If you have the assembly from above, you can use VAMB for binning the contigs
 
 ```
-VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/vamb_concat.slurm)
-VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/vamb_minimap.slurm)
-VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/vamb.slurm)
-CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/checkm.slurm vamb/bins/ vamb/checkm)
+VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB $SRC/vamb_concat.slurm)
+VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_READS:1 $SRC/vamb_minimap.slurm)
+VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB $SRC/vamb.slurm)
+CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB $SRC/checkm.slurm vamb/bins/ vamb/checkm)
 ```
 
 
@@ -228,11 +228,11 @@ SSJOB=$(sbatch --parsable --dependency=afterok:$MMSEQSJOB --array=1-$NUM_READS:1
 COUNTSSJOB=$(sbatch --parsable --dependency=afterok:$SSJOB $SRC/count_subsystems.slurm)
 SANKEYJOB=$(sbatch --parsable --dependency=afterok:$COUNTSSJOB $SRC/sankey_plot.slurm)
 
-MEGAHITJOB=$(sbatch  --parsable --dependency=afterok:$HOSTJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA --array=1-$NUM_READS:1 $SRC/megahit.slurm)
-VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/vamb_concat.slurm)
-VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_READS:1 --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/vamb_minimap.slurm)
-VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/vamb.slurm)
-CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB --export=ATAVIDE_CONDA=$ATAVIDE_CONDA $SRC/checkm.slurm vamb/bins/ vamb/checkm)
+MEGAHITJOB=$(sbatch  --parsable --dependency=afterok:$HOSTJOB --array=1-$NUM_READS:1 $SRC/megahit.slurm)
+VCJOB=$(sbatch --parsable --dependency=afterok:$MEGAHITJOB $SRC/vamb_concat.slurm)
+VMJOB=$(sbatch --parsable  --dependency=afterok:$VCJOB --array=1-$NUM_READS:1 $SRC/vamb_minimap.slurm)
+VAMBJOB=$(sbatch --parsable --dependency=afterany:$VMJOB $SRC/vamb.slurm)
+CHECKMJOB=$(sbatch --parsable --dependency=afterany:$VAMBJOB $SRC/checkm.slurm vamb/bins/ vamb/checkm)
 
 ```
 

--- a/pawsey_minion/README.md
+++ b/pawsey_minion/README.md
@@ -23,7 +23,7 @@ mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/minicond
 mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite_vamb --file ../atavide_lite_vamb.yaml
 ```
 
-Make sure you build atavide_lit/bin:
+Make sure you build atavide_lite/bin:
 
 ```
 pushd $HOME/GitHubs/atavide_lite/bin

--- a/pawsey_minion/README.md
+++ b/pawsey_minion/README.md
@@ -23,6 +23,13 @@ mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/minicond
 mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite_vamb --file ../atavide_lite_vamb.yaml
 ```
 
+Make sure you build atavide_lit/bin:
+
+```
+pushd $HOME/GitHubs/atavide_lite/bin
+make all
+popd
+```
 
 ## 0. Get your data.
 

--- a/pawsey_minion/download_human.slurm
+++ b/pawsey_minion/download_human.slurm
@@ -1,0 +1,22 @@
+#!/bin/bash
+#SBATCH --job-name=human_download
+#SBATCH --time=1-0
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=32G
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
+
+DEST=/scratch/$PAWSEY_PROJECT/$USER/Databases/human
+
+mkdir -p $DEST
+cd $DEST
+
+if [[ -e GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.gz ]]; then
+	echo "GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.gz already exists. Nothing to do";
+	touch GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.gz;
+	exit 0
+fi
+
+curl -LO https://ftp.ncbi.nlm.nih.gov/genomes/all/GCF/000/001/405/GCF_000001405.40_GRCh38.p14/GRCh38_major_release_seqs_for_alignment_pipelines/GCA_000001405.15_GRCh38_no_alt_plus_hs38d1_analysis_set.fna.gz
+echo "Downloaded human db to $DEST"

--- a/pawsey_minion/download_human.slurm
+++ b/pawsey_minion/download_human.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 DEST=/scratch/$PAWSEY_PROJECT/$USER/Databases/human
 

--- a/pawsey_minion/download_taxon_db.slurm
+++ b/pawsey_minion/download_taxon_db.slurm
@@ -1,0 +1,38 @@
+#!/bin/bash
+#SBATCH --job-name=taxon_dld
+#SBATCH --time=1-0
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=32G
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
+
+TAXDIR="/scratch/$PAWSEY_PROJECT/$USER/Databases/NCBI/taxonomy/current"
+
+mkdir -p $TAXDIR
+cd $TAXDIR;
+
+required_files=(
+  citations.dmp  delnodes.dmp  division.dmp  gc.prt
+  gencode.dmp  images.dmp  merged.dmp  names.dmp
+  nodes.dmp  readme.txt
+)
+
+missing=0
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing: $file"
+    missing=1
+  fi
+done
+
+if [[ $missing -eq 1 ]]; then
+  echo "One or more files are missing. Downloading taxdump.tar.gz..."
+  curl -LO https://ftp.ncbi.nih.gov/pub/taxonomy/taxdump.tar.gz
+  tar zxf taxdump.tar.gz && rm -f taxdump.tar.gz
+else
+  echo "All required files are present."
+fi
+
+echo "Done"

--- a/pawsey_minion/download_taxon_db.slurm
+++ b/pawsey_minion/download_taxon_db.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 TAXDIR="/scratch/$PAWSEY_PROJECT/$USER/Databases/NCBI/taxonomy/current"
 

--- a/pawsey_minion/download_uniref100.slurm
+++ b/pawsey_minion/download_uniref100.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!

--- a/pawsey_minion/download_uniref100.slurm
+++ b/pawsey_minion/download_uniref100.slurm
@@ -1,0 +1,66 @@
+#!/bin/bash
+#SBATCH --job-name=MMSeqsDld100
+#SBATCH --time=1-0
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=128G
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
+
+# Use `mmseqs databases` to find information about the preformatted databases
+# NOTE: Do not download the NT database unless you _really_ need it. The database is huge!
+
+
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
+
+CWD=`pwd`
+
+#DB can also be  UniRef100 UniRef100 GTDB etc
+DB=UniRef100
+
+
+required_files=(
+	UniRef100  UniRef100.dbtype  UniRef100_h  UniRef100_h.dbtype
+	UniRef100_h.index  UniRef100.index  UniRef100.lookup  UniRef100_mapping
+	UniRef100.source  UniRef100_taxonomy  UniRef100.version
+)
+
+missing=0
+
+DESTINATION=/scratch/$PAWSEY_PROJECT/$USER/Databases/$DB
+TMP=/scratch/$PAWSEY_PROJECT/$USER/tmp
+mkdir -p $DESTINATION $TMP
+
+cd $DESTINATION
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "$DB/$file" ]]; then
+    echo "Missing: $DB/$file"
+    missing=1
+  fi
+done
+
+if [[ $missing -eq 0 ]]; then
+  echo "All required files are present."
+  exit 0
+fi
+
+echo "Downloading required files"
+
+cd $CWD
+# delete the old Destination and make the dir to remove partial files.
+
+rm -rf $DESTINATION && mkdir -p $DESTINATION
+TPD=$(mktemp -d -p $TMP)
+echo -e "Downloading to $DESTINATION/$DB and using temp location $TPD.\nNote we download the tarball and then uncompress, so there is usually nothing in the output for a while!" >&2
+mmseqs databases --threads 8 $DB $DESTINATION/$DB $TPD
+
+
+

--- a/pawsey_minion/download_uniref50.slurm
+++ b/pawsey_minion/download_uniref50.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!

--- a/pawsey_minion/download_uniref50.slurm
+++ b/pawsey_minion/download_uniref50.slurm
@@ -1,0 +1,67 @@
+#!/bin/bash
+#SBATCH --job-name=MMSeqsDld
+#SBATCH --time=1-0
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=128G
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
+
+# Use `mmseqs databases` to find information about the preformatted databases
+# NOTE: Do not download the NT database unless you _really_ need it. The database is huge!
+
+
+
+set -euo pipefail
+trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
+
+# test we have atavide_lite conda installed, and then activate it
+eval "$(conda shell.bash hook)"
+"$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+conda activate $ATAVIDE_CONDA
+
+CWD=`pwd`
+
+#DB can also be  UniRef50 UniRef100 GTDB etc
+DB=UniRef50
+
+
+required_files=(
+	UniRef50  UniRef50.dbtype  UniRef50_h  UniRef50_h.dbtype
+	UniRef50_h.index  UniRef50.index  UniRef50.lookup  UniRef50_mapping
+	UniRef50.source  UniRef50_taxonomy  UniRef50.version
+)
+
+missing=0
+
+DESTINATION=/scratch/$PAWSEY_PROJECT/$USER/Databases/$DB
+TMP=/scratch/$PAWSEY_PROJECT/$USER/tmp
+mkdir -p $DESTINATION $TMP
+
+cd $DESTINATION
+
+for file in "${required_files[@]}"; do
+  if [[ ! -f "$DB/$file" ]]; then
+    echo "Missing: $DB/$file"
+    missing=1
+  fi
+done
+
+if [[ $missing -eq 0 ]]; then
+  echo "All required files are present."
+  exit 0
+fi
+
+echo "Downloading required files"
+
+cd $CWD
+# delete the old Destination and make the dir to remove partial files.
+
+rm -rf $DESTINATION && mkdir -p $DESTINATION
+TPD=$(mktemp -d -p $TMP)
+echo -e "Downloading to $DESTINATION/$DB and using temp location $TPD.\nNote we download the tarball and then uncompress, so there is usually nothing in the output for a while!" >&2
+mmseqs databases --threads 8 $DB $DESTINATION/$DB $TPD
+
+
+

--- a/pawsey_minion/vamb.slurm
+++ b/pawsey_minion/vamb.slurm
@@ -36,6 +36,8 @@ if [[ ! -e $OUTDIR/contigs.fna.gz ]]; then
 	exit 1;
 fi
 
+mkdir -p $OUTDIR/mapped_reads
+
 for READS in $(sort -R reads.txt); do
 	BAM=${READS/$FILEEND/.bam}
 	echo "READS: $READS BAM: $BAM" >&2;

--- a/pawsey_minion/vamb.slurm
+++ b/pawsey_minion/vamb.slurm
@@ -39,7 +39,7 @@ fi
 for READS in $(sort -R reads.txt); do
 	BAM=${READS/$FILEEND/.bam}
 	echo "READS: $READS BAM: $BAM" >&2;
-	if [[ -e $OUTDIR/mapped_reads/$BAM ]]; then
+	if [[ ! -e $OUTDIR/mapped_reads/$BAM ]]; then
 		echo "Bam file: '$OUTDIR/mapped_reads/$BAM' not found. Data generated" >&2;
 		minimap2 -t 16 -N 5 -ax map-ont $OUTDIR/contigs.mmi --split-prefix mmsplit$$ fastq/$READS | samtools view -F 3584 -b --threads 16  | samtools sort -@ 16 -o $OUTDIR/mapped_reads/$BAM -
 	fi

--- a/pawsey_minion/vamb.slurm
+++ b/pawsey_minion/vamb.slurm
@@ -41,6 +41,7 @@ for READS in $(sort -R reads.txt); do
 	echo "READS: $READS BAM: $BAM" >&2;
 	if [[ ! -e $OUTDIR/mapped_reads/$BAM ]]; then
 		echo "Bam file: '$OUTDIR/mapped_reads/$BAM' not found. Data generated" >&2;
+		mkdir -p $OUTDIR/mapped_reads
 		minimap2 -t 16 -N 5 -ax map-ont $OUTDIR/contigs.mmi --split-prefix mmsplit$$ fastq/$READS | samtools view -F 3584 -b --threads 16  | samtools sort -@ 16 -o $OUTDIR/mapped_reads/$BAM -
 	fi
 done

--- a/pawsey_minion/vamb.slurm
+++ b/pawsey_minion/vamb.slurm
@@ -14,10 +14,11 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 # test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
 "$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
-ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite_vamb"
 conda activate $ATAVIDE_CONDA
 
-module load pytorch/2.2.0-rocm5.7.3
+# module load pytorch/2.2.0-rocm5.7.3
+module load pytorch/2.7.1-rocm6.3.3
 
 if [[ ! -e DEFINITIONS.sh ]]; then
 	echo "Please create a DEFINITIONS.sh file with SOURCE, FILEEND, HOSTREMOVED" >&2

--- a/pawsey_minion/vamb_concat.slurm
+++ b/pawsey_minion/vamb_concat.slurm
@@ -13,7 +13,7 @@ trap 's=$?; echo "$0: Error on line "$LINENO": $BASH_COMMAND"; exit $s' ERR
 # test we have atavide_lite conda installed, and then activate it
 eval "$(conda shell.bash hook)"
 "$HOME/GitHubs/atavide_lite/pawsey_lib/check_atavide_lite_env.sh"
-ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite"
+ATAVIDE_CONDA="/scratch/$PAWSEY_PROJECT/$USER/software/miniconda3/atavide_lite_vamb"
 conda activate $ATAVIDE_CONDA
 
 mkdir -p vamb

--- a/pawsey_shortread/README.md
+++ b/pawsey_shortread/README.md
@@ -17,7 +17,7 @@ mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/minicond
 
 This creates an `atavide_lite` and `atavide_lite_vamb` conda environments for us to use.
 
-Make sure you build atavide_lit/bin:
+Make sure you build atavide_lite/bin:
 
 ```
 pushd $HOME/GitHubs/atavide_lite/bin

--- a/pawsey_shortread/README.md
+++ b/pawsey_shortread/README.md
@@ -17,6 +17,13 @@ mamba env create --yes --prefix /scratch/$PAWSEY_PROJECT/$USER/software/minicond
 
 This creates an `atavide_lite` and `atavide_lite_vamb` conda environments for us to use.
 
+Make sure you build atavide_lit/bin:
+
+```
+pushd $HOME/GitHubs/atavide_lite/bin
+make all
+popd
+```
 
 ## 0. Get your data.
 

--- a/pawsey_shortread/download_human.slurm
+++ b/pawsey_shortread/download_human.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32G
-#SBATCH -o slurm/human_download-%j.out
-#SBATCH -e slurm/human_download-%j.err
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
 
 DEST=/scratch/$PAWSEY_PROJECT/$USER/Databases/human
 

--- a/pawsey_shortread/download_human.slurm
+++ b/pawsey_shortread/download_human.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 DEST=/scratch/$PAWSEY_PROJECT/$USER/Databases/human
 

--- a/pawsey_shortread/download_taxon_db.slurm
+++ b/pawsey_shortread/download_taxon_db.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32G
-#SBATCH -o slurm_output/taxon_download-%j.out
-#SBATCH -e slurm_output/taxon_download-%j.err
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
 
 TAXDIR="/scratch/$PAWSEY_PROJECT/$USER/Databases/NCBI/taxonomy/current"
 

--- a/pawsey_shortread/download_taxon_db.slurm
+++ b/pawsey_shortread/download_taxon_db.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=32G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 TAXDIR="/scratch/$PAWSEY_PROJECT/$USER/Databases/NCBI/taxonomy/current"
 

--- a/pawsey_shortread/download_uniref100.slurm
+++ b/pawsey_shortread/download_uniref100.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!

--- a/pawsey_shortread/download_uniref100.slurm
+++ b/pawsey_shortread/download_uniref100.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
-#SBATCH -o %x-%j.out
-#SBATCH -e %x-%j.err
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
 
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!

--- a/pawsey_shortread/download_uniref50.slurm
+++ b/pawsey_shortread/download_uniref50.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
-#SBATCH -o slurm/%x-%j.out
-#SBATCH -e slurm/%x-%j.err
+#SBATCH -o %x-%j.out
+#SBATCH -e %x-%j.err
 
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!

--- a/pawsey_shortread/download_uniref50.slurm
+++ b/pawsey_shortread/download_uniref50.slurm
@@ -4,8 +4,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=128G
-#SBATCH -o mmseqsdld-%j.out
-#SBATCH -e mmseqsdld-%j.err
+#SBATCH -o slurm/%x-%j.out
+#SBATCH -e slurm/%x-%j.err
 
 # Use `mmseqs databases` to find information about the preformatted databases
 # NOTE: Do not download the NT database unless you _really_ need it. The database is huge!

--- a/pawsey_shortread/mmseqs_easy_taxonomy100.slurm
+++ b/pawsey_shortread/mmseqs_easy_taxonomy100.slurm
@@ -13,7 +13,7 @@
 
 
 #SBATCH --job-name=mmseqsET100
-#SBATCH --time=1-0
+#SBATCH --time=06:00:00
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=480G


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the pipeline documentation and SLURM job scripts for both the `pawsey_minion` and `pawsey_shortread` workflows. The main focus is on enhancing reproducibility, standardizing job outputs, updating environment usage, and adding missing database download scripts.

**Key changes include:**

### New Database Download Scripts

* Added new SLURM scripts for downloading required databases: human genome (`download_human.slurm`), NCBI taxonomy (`download_taxon_db.slurm`), UniRef50 (`download_uniref50.slurm`), and UniRef100 (`download_uniref100.slurm`). These scripts check for existing files and only download missing data, improving reproducibility and automation. [[1]](diffhunk://#diff-0eb8b0491595036e17c7226cdc2e0038c151ae5d4f3e9e31daa55f04210b6661R1-R22) [[2]](diffhunk://#diff-39990bd45de77483430a4a5db421197c2b24186119dbb4b3de8d7eb8eae2dd81R1-R38) [[3]](diffhunk://#diff-a9a342dc3c8b38e1640eb37db8e26b39aaa2dc4390c98f861e1583ea835d1816R1-R67) [[4]](diffhunk://#diff-1817abdfe2f48972494b0b91af983b6d440ac1cfa42935f6406a3f4cb4499685R1-R66)

### Environment and Module Updates

* Updated the conda environment used for VAMB-related jobs to `atavide_lite_vamb` for both `vamb.slurm` and `vamb_concat.slurm`, ensuring the correct dependencies are used. [[1]](diffhunk://#diff-3abc3a0e97c62e5003891f6e735fd5b8a0ae73791bc3557daa13be154047fdeaL17-R21) [[2]](diffhunk://#diff-1ee13095c17800c91727d2c9015822b8f3ea0d9158e8e208b01ef1c110301c16L16-R16)
* Updated the PyTorch module in `vamb.slurm` to a newer version (`2.7.1-rocm6.3.3`) for improved compatibility and performance.

### SLURM Job Script Standardization

* Standardized SLURM output and error file locations to `slurm/%x-%j.out` and `slurm/%x-%j.err` across all download scripts for easier log management. [[1]](diffhunk://#diff-c38ca71776a77272a5b5a6d88fd5fea078a233f3f41c9e87a037dc8af676d829L7-R8) [[2]](diffhunk://#diff-c6ff3a6366ace7943ce0efff6d8ac7b3e82c2e7bd80d84825757509a056290a4L7-R8) [[3]](diffhunk://#diff-f7c741c8316e68df4465dc3287bbf35e4aa0629d163138de4bc12f1c9b13bf88L7-R8) [[4]](diffhunk://#diff-027dc6ccdcf1365e0bb3615f47aece8875aadc1cadb761f087d7589537612f06L7-R8)

### Pipeline Documentation and Logic Fixes

* Added a reminder in both `pawsey_minion/README.md` and `pawsey_shortread/README.md` to build the `atavide_lite/bin` executables before running the pipeline. [[1]](diffhunk://#diff-b98b5180ad7b8fc94bfc6d534810d06eaf82f7f573bd67e4cbd055fc58cbc10aR26-R32) [[2]](diffhunk://#diff-d11233ce1332e0204f4d4c91ce3596026ca9afa4d67a976e4fd1644162adc496R20-R26)
* Fixed SLURM submission commands in the README and pipeline to remove unnecessary `--export=ATAVIDE_CONDA=$ATAVIDE_CONDA` where not required, and corrected job dependencies. [[1]](diffhunk://#diff-b98b5180ad7b8fc94bfc6d534810d06eaf82f7f573bd67e4cbd055fc58cbc10aL125-R132) [[2]](diffhunk://#diff-b98b5180ad7b8fc94bfc6d534810d06eaf82f7f573bd67e4cbd055fc58cbc10aL183-R193) [[3]](diffhunk://#diff-b98b5180ad7b8fc94bfc6d534810d06eaf82f7f573bd67e4cbd055fc58cbc10aL224-R235)
* Corrected a logic bug in `vamb.slurm` so that BAM files are only generated if they do not already exist, preventing unnecessary recomputation.

### Resource Allocation Adjustment

* Reduced the wall time for `mmseqs_easy_taxonomy100.slurm` from 1 day to 6 hours, likely reflecting more accurate job duration requirements.