### PR TITLE
renaming and editing

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -111,7 +111,7 @@ Assembly can begin from cleaned reads without waiting for read-based taxonomy:
 ```bash
 ASSEMBLY_JOB=$(sbatch --parsable \
   --dependency="afterok:${HOST_JOB}" \
-  "$ATAVIDE_PROFILE/megahit_hostremoved.slurm")
+  "$ATAVIDE_PROFILE/megahit_allreads.slurm")
 ```
 
 Prepare FASTA for MMseqs2:

--- a/pawsey_shortread/README.md
+++ b/pawsey_shortread/README.md
@@ -135,7 +135,21 @@ We use these assemblies, e.g. for binning with VAMB. The assemblies are not used
 to complete before submitting the subsequent jobs.
 
 ```
-MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/megahit_hostremoved.slurm)
+MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/megahit_allreads.slurm)
+```
+
+### 8b. If you want to do individual assemblies, and then merge them with contigger:
+
+First, do the assemblies separately:
+
+```
+MEGAHITJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$HOSTJOB $PAWSEY_SRC/megahit.slurm)
+```
+
+Then, merge the assemblies with contigger:
+
+```
+TBD!
 ```
 
 ## 9. Convert to fasta.
@@ -260,8 +274,8 @@ Then we use the usual VAMB approach to bin the contigs.
 </summary>
 
 
-Assemble using the `megahit_hostremoved.slurm` script above. This will take a while to run, so do it early! Also note that `megahit` can continue if it is interuppted. Make sure the `--continue` flag is active 
-in the `megahit_hostremoved.slurm` script.
+Assemble using the `megahit_allreads.slurm` script above. This will take a while to run, so do it early! Also note that `megahit` can continue if it is interuppted. Make sure the `--continue` flag is active 
+in the `megahit_allreads.slurm` script.
 
 ```
 VCRJOB=$(sbatch --parsable $PAWSEY_SRC/vamb_concat_crass.slurm samples.tsv)
@@ -294,7 +308,7 @@ directory to find the error.
 ```
 JOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 $PAWSEY_SRC/fastp.slurm)
 HOSTJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$JOB $PAWSEY_SRC/host_removal.slurm)
-MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/megahit_hostremoved.slurm)
+MEGAHITHR=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/megahit_allreads.slurm)
 sbatch --parsable $PAWSEY_SRC/16S_detection_single.slurm
 FAJOB=$(sbatch --parsable --dependency=afterok:$HOSTJOB $PAWSEY_SRC/fastq2fasta.slurm)
 MMSEQSJOB=$(sbatch --parsable --array=1-$NUM_R1_READS:1 --dependency=afterok:$FAJOB $PAWSEY_SRC/mmseqs_easy_taxonomy.slurm)

--- a/pawsey_shortread/megahit_allreads.slurm
+++ b/pawsey_shortread/megahit_allreads.slurm
@@ -5,8 +5,8 @@
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
 #SBATCH --mem=960G
-#SBATCH -o slurm_output/megahit_slurm/%x-%j.out
-#SBATCH -e slurm_output/megahit_slurm/%x-%j.err
+#SBATCH -o slurm_output/%x-%j.out
+#SBATCH -e slurm_output/%x-%j.err
 
 
 


### PR DESCRIPTION
This pull request updates the assembly workflow documentation and scripts to use the `megahit_allreads.slurm` script instead of `megahit_hostremoved.slurm`, and adds instructions for performing individual assemblies and merging them. The changes also include a file rename and minor output path adjustments.

**Workflow and documentation updates:**

* Updated all references and job submissions in `README.md` to use the new `megahit_allreads.slurm` script instead of `megahit_hostremoved.slurm`. [[1]](diffhunk://#diff-d11233ce1332e0204f4d4c91ce3596026ca9afa4d67a976e4fd1644162adc496L138-R152) [[2]](diffhunk://#diff-d11233ce1332e0204f4d4c91ce3596026ca9afa4d67a976e4fd1644162adc496L263-R278) [[3]](diffhunk://#diff-d11233ce1332e0204f4d4c91ce3596026ca9afa4d67a976e4fd1644162adc496L297-R311)
* Added instructions for running individual assemblies and merging them with contigger in the `README.md`.

**Script and file changes:**

* Renamed `megahit_hostremoved.slurm` to `megahit_allreads.slurm` and updated output/error log paths to `slurm_output/%x-%j.out` and `slurm_output/%x-%j.err`.